### PR TITLE
docs: enhance README with philosophy, tool comparison, and roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,9 +116,49 @@ tokuye --project-root .
 
 ---
 
-## Philosophy & Features
+## Philosophy & Design Goals
 
 Tokuye aims to be an intelligent development agent that **understands your entire project context** without requiring you to manually provide it. Instead of repeatedly copying code snippets or explaining your codebase, Tokuye automatically analyzes your repository and intelligently searches for relevant code to avoid duplication and maintain consistency.
+
+### Why Tokuye?
+
+**Stay in Your Terminal, Keep Your Editor**
+
+We built Tokuye because we wanted AI assistance without abandoning our familiar development environment. No need to switch to a specific IDE or learn a new editor — Tokuye runs in your terminal and works alongside Vim, Emacs, or whatever editor you prefer.
+
+**AI as a Teammate, Not a Replacement**
+
+Tokuye is designed to fit into your existing Git workflow:
+1. You describe the issue
+2. AI creates a branch and implements changes
+3. You review the PR and merge (or request changes)
+
+No dramatic workflow changes. Just AI-powered assistance that respects how you already work.
+
+**Project-Level Cost Management**
+
+AI development tools should be a project cost, not a personal expense. That's why Tokuye uses AWS Bedrock with IAM credentials — your organization can issue project-specific credentials and track costs per project/team. No need for individual subscriptions or personal credit cards.
+
+(Sorry, Google Cloud fans — we went with AWS this time! 😅)
+
+**Key Differentiators:**
+
+- **Terminal-First**: Works with your existing editor setup (Vim, Emacs, etc.)
+- **Transparent Git Operations**: You see exactly what branches and commits are created
+- **Enterprise-Friendly**: IAM-based access control, potential for VPC-internal deployment
+- **Project Cost Allocation**: Costs tied to AWS projects, not individual developers
+
+### When to Choose Tokuye
+
+✅ **Good fit if you:**
+- Prefer terminal-based workflows
+- Want to keep using your favorite editor
+- Need project-level cost tracking and IAM control
+- Work in environments where AWS access is easier than new SaaS subscriptions
+
+❌ **Consider alternatives if you:**
+- Prefer tight IDE integration (Cursor might be better)
+- Need a fully managed cloud sandbox (Devin might be better)
 
 ### Core Principles
 
@@ -162,9 +202,12 @@ Tokuye aims to be an intelligent development agent that **understands your entir
 
 ### Why AWS Bedrock Only?
 
-Tokuye exclusively supports AWS Bedrock for LLM access. This design choice is intentional:
+Tokuye exclusively supports AWS Bedrock for LLM access. This isn't a limitation — it's a deliberate design choice aligned with our philosophy:
 
+- **Cost Ownership**: AI tool costs should be borne by the project, not the developer. AWS IAM allows organizations to issue project-specific credentials and track costs per project/team.
 - **Enterprise-Friendly**: In many business environments, obtaining AWS IAM credentials is straightforward
+- **Access Control**: IAM policies provide fine-grained control over who can use which models
+- **Audit Trail**: CloudTrail integration for compliance and usage tracking
 - **No New Subscriptions**: Avoids the hassle of setting up new Anthropic or OpenAI subscriptions, which can be bureaucratically complex in some organizations
 - **Simple Authentication**: Works with standard boto3 configuration (`AWS_ACCESS_KEY_ID`, `AWS_PROFILE`, etc.)
 
@@ -246,6 +289,7 @@ Create a `.tokuye/summary.ignore` file to exclude specific paths from repository
 ## Roadmap
 
 - [ ] MCP (Model Context Protocol) client support
+- [ ] Slack integration for team collaboration
 - [ ] Custom system prompt configuration
 - [ ] Multi-region cost tracking
 - [ ] Extended model support


### PR DESCRIPTION
- Add "Why Tokuye?" section explaining terminal-first approach and workflow integration
- Clarify project-level cost management philosophy for AWS Bedrock adoption
- Add Slack integration to roadmap
- Expand "Why AWS Bedrock Only?" section with cost ownership and access control details