### PR TITLE
feat: introduce global config support via XDG_CONFIG_HOME

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,17 @@ Tokuye exclusively supports AWS Bedrock for LLM access. This isn't a limitation 
 
 ## Configuration
 
-Create a `.tokuye/config.yaml` file in your project root:
+Tokuye supports two layers of configuration. Settings are resolved in the following order (later wins):
+
+1. **Pydantic defaults / `.env`**
+2. **Global config** — `$XDG_CONFIG_HOME/tokuye/config.yaml` (default: `~/.config/tokuye/config.yaml`)
+3. **Project config** — `<project_root>/.tokuye/config.yaml`
+
+> **Exception:** `mcp_servers` is **merged** across global and project configs instead of being replaced. See [MCP Server Merging](#mcp-server-merging) for details.
+
+### Project Config
+
+Create a `.tokuye/config.yaml` in your project root:
 
 ```yaml
 # Model Configuration
@@ -231,6 +241,37 @@ strands_session_dir: sessions
 name: Alice  # Agent character name
 theme: tokyo-night  # Textual theme (see Textual docs for options)
 ```
+
+### Global Config
+
+To avoid repeating the same settings in every project, create a global config:
+
+```bash
+# Create the directory
+mkdir -p "${XDG_CONFIG_HOME:-$HOME/.config}/tokuye"
+
+# Create the global config
+cat > "${XDG_CONFIG_HOME:-$HOME/.config}/tokuye/config.yaml" << 'EOF'
+bedrock_model_id: global.anthropic.claude-sonnet-4-5-20250929-v1:0
+model_temperature: 0.2
+name: Alice
+
+mcp_servers:
+  - name: "github-mcp"
+    type: "stdio"
+    command: "npx"
+    args: ["-y", "@modelcontextprotocol/server-github"]
+    env:
+      GITHUB_PERSONAL_ACCESS_TOKEN: "${GITHUB_TOKEN}"
+EOF
+```
+
+Any key set here applies to **all** projects. If the same key (except `mcp_servers`) appears in a project config, the project value takes precedence.
+
+| Scope | Path | Wins for scalar keys | `mcp_servers` behaviour |
+|-------|------|---------------------|------------------------|
+| Global | `$XDG_CONFIG_HOME/tokuye/config.yaml` | Only if project doesn't set it | Base list |
+| Project | `<project_root>/.tokuye/config.yaml` | Always | Merged onto global list |
 
 ### MCP (Model Context Protocol) Support
 
@@ -330,6 +371,67 @@ mcp_servers:
     type: "sse"
     url: "http://localhost:3000/sse"
 ```
+
+#### MCP Server Merging
+
+`mcp_servers` is the only config key that is **merged** between global and project configs. All other keys are simply overridden by the project config.
+
+**How merging works:**
+
+1. Global `mcp_servers` are loaded first as the base list.
+2. Project `mcp_servers` are applied on top:
+   - If a server has the **same `name`** as a global entry, the **project entry replaces it entirely**.
+   - If a server has a **new `name`**, it is **appended** to the list.
+   - Global entries whose `name` does not appear in the project config are **kept as-is**.
+
+**Example:**
+
+```yaml
+# Global config (~/.config/tokuye/config.yaml)
+mcp_servers:
+  - name: "github"
+    type: "stdio"
+    command: "npx"
+    args: ["-y", "@modelcontextprotocol/server-github"]
+    env:
+      GITHUB_PERSONAL_ACCESS_TOKEN: "${GITHUB_TOKEN}"
+
+  - name: "slack"
+    type: "stdio"
+    command: "npx"
+    args: ["-y", "@anthropic/mcp-server-slack"]
+    env:
+      SLACK_BOT_TOKEN: "${SLACK_BOT_TOKEN}"
+```
+
+```yaml
+# Project config (.tokuye/config.yaml)
+mcp_servers:
+  # Override "github" — use different allowed_tools for this project
+  - name: "github"
+    type: "stdio"
+    command: "npx"
+    args: ["-y", "@modelcontextprotocol/server-github"]
+    env:
+      GITHUB_PERSONAL_ACCESS_TOKEN: "${GITHUB_TOKEN}"
+    allowed_tools:
+      - "get_pull_request"
+      - "list_pull_requests"
+
+  # Add a project-specific server
+  - name: "filesystem"
+    type: "stdio"
+    command: "npx"
+    args: ["-y", "@modelcontextprotocol/server-filesystem", "/tmp/sandbox"]
+```
+
+**Result:** The agent sees three MCP servers:
+
+| Server | Source | Notes |
+|--------|--------|-------|
+| `github` | Project | Replaced — project version has `allowed_tools` |
+| `slack` | Global | Kept — not mentioned in project config |
+| `filesystem` | Project | Added — new entry |
 
 > **Note**: MCP support requires the `strands-agents-tools[mcp]` extra, which is included by default. If you encounter import errors, ensure the `mcp` package is installed: `pip install 'mcp>=1.23.0,<2.0.0'`
 

--- a/src/tokuye/utils/config.py
+++ b/src/tokuye/utils/config.py
@@ -72,59 +72,118 @@ def _expand_env_vars(value: str) -> str:
     return re.sub(r"\$\{([^}]+)}", _replacer, value)
 
 
-def load_yaml_config(settings_instance: Settings) -> Settings:
+def _get_global_config_path() -> Path:
+    """Return the path to the global config file.
+
+    Uses ``$XDG_CONFIG_HOME/tokuye/config.yaml`` if the environment variable
+    is set, otherwise falls back to ``~/.config/tokuye/config.yaml``.
     """
-    Load settings from .tokuye/config.yaml and update settings instance
+    xdg = os.environ.get("XDG_CONFIG_HOME")
+    if xdg:
+        base = Path(xdg)
+    else:
+        base = Path.home() / ".config"
+    return base / "tokuye" / "config.yaml"
+
+
+def _parse_mcp_servers(raw_list: list) -> List[Settings.McpServerConfig]:
+    """Parse a list of raw MCP server dicts into ``McpServerConfig`` objects."""
+    configs: List[Settings.McpServerConfig] = []
+    for server_cfg in raw_list:
+        try:
+            if "env" in server_cfg and isinstance(server_cfg["env"], dict):
+                server_cfg["env"] = {
+                    k: _expand_env_vars(v)
+                    for k, v in server_cfg["env"].items()
+                }
+            configs.append(Settings.McpServerConfig(**server_cfg))
+        except Exception as e:
+            logger.warning("Invalid MCP server config: %s, error: %s", server_cfg, e)
+    return configs
+
+
+def _apply_yaml_to_settings(
+    settings_instance: Settings,
+    yaml_config: dict,
+    merge_mcp: bool = False,
+) -> None:
+    """Apply *yaml_config* values onto *settings_instance* in-place.
+
+    When *merge_mcp* is ``True`` the ``mcp_servers`` list is **merged** with
+    the existing value instead of replaced.  Servers whose ``name`` matches an
+    existing entry are replaced; others are appended.  This allows a project
+    config to override individual servers defined in the global config while
+    keeping the rest.
+    """
+    simple_keys = [
+        "bedrock_model_id",
+        "bedrock_embedding_model_id",
+        "model_temperature",
+        "pr_branch_prefix",
+        "strands_session_dir",
+        "name",
+        "theme",
+    ]
+    for key in simple_keys:
+        if key in yaml_config:
+            setattr(settings_instance, key, yaml_config[key])
+
+    if "mcp_servers" in yaml_config:
+        new_servers = _parse_mcp_servers(yaml_config["mcp_servers"])
+        if merge_mcp and settings_instance.mcp_servers:
+            # Build a dict keyed by server name from the existing list
+            merged: dict[str, Settings.McpServerConfig] = {
+                s.name: s for s in settings_instance.mcp_servers
+            }
+            # Project-side entries override by name; new names are appended
+            for s in new_servers:
+                merged[s.name] = s
+            settings_instance.mcp_servers = list(merged.values())
+        else:
+            settings_instance.mcp_servers = new_servers
+
+
+def load_yaml_config(settings_instance: Settings) -> Settings:  # noqa: C901
+    """
+    Load settings from global and project config.yaml files.
+
+    Resolution order (later wins):
+      1. Pydantic defaults / ``.env``
+      2. Global config  — ``$XDG_CONFIG_HOME/tokuye/config.yaml``
+      3. Project config — ``<project_root>/.tokuye/config.yaml``
+
+    ``mcp_servers`` is special-cased: the project list is **merged** with the
+    global list rather than replacing it.  See :func:`_apply_yaml_to_settings`.
     """
     if not settings_instance.project_root:
         raise ValueError("project_root must be set before loading YAML config")
 
     config_path = settings_instance.project_root / ".tokuye" / "config.yaml"
 
-    # Load only if config.yaml exists
-    if config_path.exists():
-        with open(config_path, "r") as f:
-            yaml_config = yaml.safe_load(f)
+    # --- 1. Global config ------------------------------------------------
+    global_path = _get_global_config_path()
+    if global_path.exists():
+        try:
+            with open(global_path, "r") as f:
+                global_cfg = yaml.safe_load(f)
+            if global_cfg:
+                _apply_yaml_to_settings(settings_instance, global_cfg)
+                logger.info("Loaded global config from %s", global_path)
+        except Exception as e:
+            logger.warning("Failed to load global config (%s): %s", global_path, e)
 
-        # Overwrite with settings loaded from YAML
-        if yaml_config:
-            if "bedrock_model_id" in yaml_config:
-                settings_instance.bedrock_model_id = yaml_config["bedrock_model_id"]
-            if "bedrock_embedding_model_id" in yaml_config:
-                settings_instance.bedrock_embedding_model_id = yaml_config[
-                    "bedrock_embedding_model_id"
-                ]
-            if "model_temperature" in yaml_config:
-                settings_instance.model_temperature = yaml_config["model_temperature"]
-            if "pr_branch_prefix" in yaml_config:
-                settings_instance.pr_branch_prefix = yaml_config["pr_branch_prefix"]
-            if "strands_session_dir" in yaml_config:
-                settings_instance.strands_session_dir = yaml_config[
-                    "strands_session_dir"
-                ]
-            if "name" in yaml_config:
-                settings_instance.name = yaml_config["name"]
-            if "theme" in yaml_config:
-                settings_instance.theme = yaml_config["theme"]
-            if "mcp_servers" in yaml_config:
-                mcp_configs = []
-                for server_cfg in yaml_config["mcp_servers"]:
-                    try:
-                        # Expand ${ENV_VAR} references in env values
-                        if "env" in server_cfg and isinstance(server_cfg["env"], dict):
-                            server_cfg["env"] = {
-                                k: _expand_env_vars(v)
-                                for k, v in server_cfg["env"].items()
-                            }
-                        mcp_configs.append(
-                            Settings.McpServerConfig(**server_cfg)
-                        )
-                    except Exception as e:
-                        import logging
-                        logging.getLogger(__name__).warning(
-                            f"Invalid MCP server config: {server_cfg}, error: {e}"
-                        )
-                settings_instance.mcp_servers = mcp_configs
+    # --- 2. Project config (overrides global; mcp_servers are merged) -----
+    if config_path.exists():
+        try:
+            with open(config_path, "r") as f:
+                project_cfg = yaml.safe_load(f)
+            if project_cfg:
+                _apply_yaml_to_settings(
+                    settings_instance, project_cfg, merge_mcp=True
+                )
+                logger.info("Loaded project config from %s", config_path)
+        except Exception as e:
+            logger.warning("Failed to load project config (%s): %s", config_path, e)
 
     return settings_instance
 


### PR DESCRIPTION
- Add global config loading from $XDG_CONFIG_HOME/tokuye/config.yaml (defaults to ~/.config/tokuye/config.yaml)
- Resolution order: defaults < global config < project config
- mcp_servers is merged (not replaced) between global and project configs: same-name entries are overridden by project, others are kept
- Extract _get_global_config_path, _parse_mcp_servers, _apply_yaml_to_settings helpers for clarity
- Fully backward compatible: no global config = same behavior as before
- Update README with Global Config section and MCP Server Merging docs