### PR TITLE
feat: add gh tools - pr_get_comments, submit_pull_request, issue_list…

### DIFF
--- a/src/tokuye/tools/strands_tools/__init__.py
+++ b/src/tokuye/tools/strands_tools/__init__.py
@@ -9,7 +9,12 @@ from tokuye.tools.strands_tools.phase_tool import report_phase
 from tokuye.tools.strands_tools.pr_review_tools import (pr_diff, pr_list,
                                                         pr_review_comment,
                                                         pr_review_submit,
-                                                        pr_view)
+                                                        pr_view,
+                                                        pr_get_comments)
+from tokuye.tools.strands_tools.pr_create_tool import submit_pull_request
+from tokuye.tools.strands_tools.issue_tools import (issue_list,
+                                                    issue_view,
+                                                    issue_get_comments)
 from tokuye.tools.strands_tools.repo_description import \
     generate_repo_description_tool
 from tokuye.tools.strands_tools.repo_summary import repo_summarize
@@ -43,5 +48,10 @@ all_tools = [
     pr_diff,
     pr_review_comment,
     pr_review_submit,
+    pr_get_comments,
+    submit_pull_request,
+    issue_list,
+    issue_view,
+    issue_get_comments,
     report_phase,
 ]

--- a/src/tokuye/tools/strands_tools/gh_utils.py
+++ b/src/tokuye/tools/strands_tools/gh_utils.py
@@ -1,0 +1,67 @@
+"""
+Shared utility for running `gh` CLI commands.
+
+Imported by pr_review_tools, pr_create_tool, and issue_tools to avoid
+duplicating the subprocess wrapper.
+"""
+
+import logging
+import subprocess
+from typing import Optional
+
+from tokuye.utils.config import settings
+
+logger = logging.getLogger(__name__)
+
+
+def run_gh(
+    args: list[str],
+    *,
+    stdin_input: Optional[str] = None,
+    max_output_chars: int = 80_000,
+) -> str:
+    """
+    Run a `gh` CLI command and return stdout.
+
+    Args:
+        args: Arguments to pass to `gh` (e.g. ["pr", "list"]).
+        stdin_input: Optional string to feed to stdin.
+        max_output_chars: Truncate stdout beyond this limit to avoid token explosion.
+
+    Returns:
+        stdout string from the command.
+
+    Raises:
+        RuntimeError: If `gh` is not found or the command fails.
+    """
+    cmd = ["gh"] + args
+    logger.info("Running: %s", " ".join(cmd))
+
+    try:
+        result = subprocess.run(
+            cmd,
+            cwd=settings.project_root,
+            input=stdin_input,
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+    except FileNotFoundError:
+        raise RuntimeError(
+            "gh CLI is not installed. "
+            "Install it from https://cli.github.com/ and run `gh auth login`."
+        )
+    except subprocess.TimeoutExpired:
+        raise RuntimeError("gh command timed out after 60 seconds.")
+
+    if result.returncode != 0:
+        stderr = result.stderr.strip()
+        raise RuntimeError(f"gh command failed (exit {result.returncode}): {stderr}")
+
+    output = result.stdout
+    if len(output) > max_output_chars:
+        output = (
+            output[:max_output_chars]
+            + f"\n\n... (truncated at {max_output_chars} chars)"
+        )
+    return output

--- a/src/tokuye/tools/strands_tools/issue_tools.py
+++ b/src/tokuye/tools/strands_tools/issue_tools.py
@@ -1,0 +1,224 @@
+"""
+GitHub Issue tools using the `gh` CLI.
+
+Provides tools to list issues, view issue details, and read issue comments.
+Requires `gh` CLI to be installed and authenticated.
+"""
+
+import json
+import logging
+
+from strands import tool
+
+from tokuye.tools.strands_tools.gh_utils import run_gh as _run_gh
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# 1. Issue List
+# ---------------------------------------------------------------------------
+
+
+@tool(
+    name="issue_list",
+    description=(
+        "List issues in the current repository. "
+        "Returns issue number, title, author, labels, and creation date. "
+        "Supports filtering by state and labels."
+    ),
+)
+def issue_list(
+    state: str = "open",
+    limit: int = 30,
+    labels: str = "",
+) -> str:
+    """
+    List issues in the current repository.
+
+    Args:
+        state: Issue state filter — "open", "closed", or "all". Defaults to "open".
+        limit: Maximum number of issues to return. Defaults to 30.
+        labels: Comma-separated label names to filter by (e.g. "bug,help wanted").
+                Leave empty to skip label filtering.
+
+    Returns:
+        Formatted list of issues.
+    """
+    try:
+        args = [
+            "issue", "list",
+            "--state", state,
+            "--limit", str(limit),
+            "--json",
+            "number,title,author,url,labels,assignees,createdAt,updatedAt,state",
+        ]
+
+        if labels.strip():
+            args.extend(["--label", labels.strip()])
+
+        raw = _run_gh(args)
+        issues = json.loads(raw)
+
+        if not issues:
+            label_note = f" with label(s) '{labels}'" if labels.strip() else ""
+            return f"No {state} issues found{label_note}."
+
+        lines = [f"Found {len(issues)} {state} issue(s):\n"]
+        for issue in issues:
+            author = issue.get("author", {}).get("login", "unknown")
+            label_names = [lb.get("name", "") for lb in issue.get("labels", [])]
+            label_str = f"  Labels: {', '.join(label_names)}" if label_names else ""
+            assignees = [a.get("login", "") for a in issue.get("assignees", [])]
+            assignee_str = (
+                f"  Assignees: {', '.join(assignees)}" if assignees else ""
+            )
+            lines.append(
+                f"  #{issue['number']}  {issue['title']}\n"
+                f"    Author: {author} | State: {issue.get('state', 'N/A')}\n"
+                f"    Created: {issue.get('createdAt', 'N/A')}"
+                f" | Updated: {issue.get('updatedAt', 'N/A')}\n"
+                + (f"    {label_str}\n" if label_str else "")
+                + (f"    {assignee_str}\n" if assignee_str else "")
+                + f"    URL: {issue['url']}"
+            )
+        return "\n".join(lines)
+
+    except Exception as e:
+        return f"Error listing issues: {e}"
+
+
+# ---------------------------------------------------------------------------
+# 2. Issue View
+# ---------------------------------------------------------------------------
+
+
+@tool(
+    name="issue_view",
+    description=(
+        "Get detailed information about a specific issue by number. "
+        "Returns title, body, author, labels, assignees, and state. "
+        "Use this to understand the full context of an issue."
+    ),
+)
+def issue_view(issue_number: int) -> str:
+    """
+    View detailed information about an issue.
+
+    Args:
+        issue_number: The issue number.
+
+    Returns:
+        Formatted issue details.
+    """
+    try:
+        raw = _run_gh([
+            "issue", "view", str(issue_number),
+            "--json",
+            "number,title,body,author,state,labels,assignees,"
+            "milestone,createdAt,updatedAt,url,comments",
+        ])
+
+        issue = json.loads(raw)
+        author = issue.get("author", {}).get("login", "unknown")
+
+        lines = [
+            f"Issue #{issue['number']}: {issue['title']}",
+            f"State: {issue.get('state', 'N/A')}",
+            f"Author: {author}",
+            f"Created: {issue.get('createdAt', 'N/A')}"
+            f" | Updated: {issue.get('updatedAt', 'N/A')}",
+            f"URL: {issue['url']}",
+        ]
+
+        # Labels
+        labels = issue.get("labels", [])
+        if labels:
+            label_names = [lb.get("name", "") for lb in labels]
+            lines.append(f"Labels: {', '.join(label_names)}")
+
+        # Assignees
+        assignees = issue.get("assignees", [])
+        if assignees:
+            assignee_names = [a.get("login", "") for a in assignees]
+            lines.append(f"Assignees: {', '.join(assignee_names)}")
+
+        # Milestone
+        milestone = issue.get("milestone")
+        if milestone:
+            lines.append(f"Milestone: {milestone.get('title', 'N/A')}")
+
+        # Body
+        body = issue.get("body", "").strip()
+        if body:
+            lines.append(f"\n--- Description ---\n{body}")
+        else:
+            lines.append("\n--- Description ---\n(no description)")
+
+        # Comment count summary (full content via issue_get_comments)
+        comments = issue.get("comments", [])
+        if comments:
+            lines.append(
+                f"\n--- Comments ({len(comments)}) ---"
+                "\n(Use issue_get_comments to read full comment content)"
+            )
+        else:
+            lines.append("\n--- Comments ---\n(no comments)")
+
+        return "\n".join(lines)
+
+    except Exception as e:
+        return f"Error viewing issue #{issue_number}: {e}"
+
+
+# ---------------------------------------------------------------------------
+# 3. Issue Get Comments
+# ---------------------------------------------------------------------------
+
+
+@tool(
+    name="issue_get_comments",
+    description=(
+        "Get all comments on a specific issue by number. "
+        "Returns each comment with author, timestamp, and full body text. "
+        "Use this to read the full discussion history of an issue."
+    ),
+)
+def issue_get_comments(issue_number: int) -> str:
+    """
+    Retrieve all comments on an issue.
+
+    Args:
+        issue_number: The issue number.
+
+    Returns:
+        Formatted string of all comments with author, timestamp, and body.
+    """
+    try:
+        raw = _run_gh([
+            "api",
+            f"repos/{{owner}}/{{repo}}/issues/{issue_number}/comments",
+            "--paginate",
+        ])
+        comments = json.loads(raw)
+
+        if not comments:
+            return f"Issue #{issue_number} has no comments."
+
+        lines = [f"Comments on Issue #{issue_number} ({len(comments)} total):\n"]
+        for i, c in enumerate(comments, start=1):
+            author = c.get("user", {}).get("login", "unknown")
+            created_at = c.get("created_at", "N/A")
+            updated_at = c.get("updated_at", "N/A")
+            body = c.get("body", "").strip()
+            lines.append(
+                f"[{i}] {author}  {created_at}"
+                + (f" (updated: {updated_at})" if updated_at != created_at else "")
+            )
+            lines.append(body)
+            lines.append("")  # blank line between comments
+
+        return "\n".join(lines)
+
+    except Exception as e:
+        return f"Error getting comments for issue #{issue_number}: {e}"

--- a/src/tokuye/tools/strands_tools/pr_create_tool.py
+++ b/src/tokuye/tools/strands_tools/pr_create_tool.py
@@ -1,0 +1,80 @@
+"""
+GitHub Pull Request creation tool using the `gh` CLI.
+
+Provides a single tool to open a pull request from the current branch.
+Requires `gh` CLI to be installed and authenticated.
+"""
+
+import json
+import logging
+
+from strands import tool
+
+from tokuye.tools.strands_tools.gh_utils import run_gh as _run_gh
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Submit Pull Request
+# ---------------------------------------------------------------------------
+
+
+@tool(
+    name="submit_pull_request",
+    description=(
+        "Create a new pull request on GitHub from the current branch. "
+        "Generates an appropriate title and description based on the changes, "
+        "then opens the PR via the gh CLI. "
+        "Defaults to draft mode to prevent accidental publication. "
+        "IMPORTANT: Only call this when explicitly instructed by the user."
+    ),
+)
+def submit_pull_request(
+    title: str,
+    body: str,
+    base: str = "",
+    draft: bool = True,
+) -> str:
+    """
+    Create a pull request on GitHub.
+
+    Args:
+        title: The pull request title.
+        body: The pull request description (markdown supported).
+        base: Target branch to merge into. Defaults to the repository's default branch.
+        draft: Whether to open as a draft PR. Defaults to True.
+
+    Returns:
+        Result message including the PR URL.
+    """
+    try:
+        args = [
+            "pr", "create",
+            "--title", title,
+            "--body", body,
+        ]
+
+        if base.strip():
+            args.extend(["--base", base.strip()])
+
+        if draft:
+            args.append("--draft")
+
+        raw = _run_gh(args)
+
+        # gh pr create returns the PR URL as the last line of stdout
+        url = raw.strip().splitlines()[-1] if raw.strip() else "(URL not available)"
+
+        draft_label = " [DRAFT]" if draft else ""
+        base_label = f" → {base}" if base.strip() else ""
+
+        return (
+            f"Pull request created successfully{draft_label}{base_label}.\n"
+            f"  Title: {title}\n"
+            f"  URL: {url}\n"
+            f"\nDescription:\n{body}"
+        )
+
+    except Exception as e:
+        return f"Error creating pull request: {e}"

--- a/src/tokuye/tools/strands_tools/pr_review_tools.py
+++ b/src/tokuye/tools/strands_tools/pr_review_tools.py
@@ -1,73 +1,19 @@
 """
 GitHub Pull Request review tools using the `gh` CLI.
 
-These tools enable listing, viewing, diffing, and reviewing pull requests
+These tools enable listing, viewing, diffing, reviewing, and reading comments on pull requests
 directly from the agent, without requiring GitHub MCP Server.
 Requires `gh` CLI to be installed and authenticated.
 """
 
 import json
 import logging
-import subprocess
 from typing import Optional
 
 from strands import tool
-from tokuye.utils.config import settings
+from tokuye.tools.strands_tools.gh_utils import run_gh as _run_gh
 
 logger = logging.getLogger(__name__)
-
-
-def _run_gh(
-    args: list[str],
-    *,
-    stdin_input: Optional[str] = None,
-    max_output_chars: int = 80_000,
-) -> str:
-    """
-    Run a `gh` CLI command and return stdout.
-
-    Args:
-        args: Arguments to pass to `gh` (e.g. ["pr", "list"]).
-        stdin_input: Optional string to feed to stdin.
-        max_output_chars: Truncate stdout beyond this limit to avoid token explosion.
-
-    Returns:
-        stdout string from the command.
-
-    Raises:
-        RuntimeError: If `gh` is not found or the command fails.
-    """
-    cmd = ["gh"] + args
-    logger.info("Running: %s", " ".join(cmd))
-
-    try:
-        result = subprocess.run(
-            cmd,
-            cwd=settings.project_root,
-            input=stdin_input,
-            capture_output=True,
-            text=True,
-            timeout=60,
-        )
-    except FileNotFoundError:
-        raise RuntimeError(
-            "gh CLI is not installed. "
-            "Install it from https://cli.github.com/ and run `gh auth login`."
-        )
-    except subprocess.TimeoutExpired:
-        raise RuntimeError("gh command timed out after 60 seconds.")
-
-    if result.returncode != 0:
-        stderr = result.stderr.strip()
-        raise RuntimeError(f"gh command failed (exit {result.returncode}): {stderr}")
-
-    output = result.stdout
-    if len(output) > max_output_chars:
-        output = (
-            output[:max_output_chars]
-            + f"\n\n... (truncated at {max_output_chars} chars)"
-        )
-    return output
 
 
 # ---------------------------------------------------------------------------
@@ -447,3 +393,98 @@ def pr_review_submit(
 
     except Exception as e:
         return f"Error submitting review for PR #{pr_number}: {e}"
+
+
+# ---------------------------------------------------------------------------
+# 6. PR Get Comments (read all comments on a PR)
+# ---------------------------------------------------------------------------
+
+
+@tool(
+    name="pr_get_comments",
+    description=(
+        "Get all comments on a specific pull request by number. "
+        "Returns both general issue-level comments and inline review comments "
+        "(diff-level comments with file path and line number). "
+        "Use this to review the existing discussion history before adding a new review."
+    ),
+)
+def pr_get_comments(pr_number: int) -> str:
+    """
+    Retrieve all comments on a pull request.
+
+    Fetches two types of comments:
+    - Issue comments: general conversation on the PR thread.
+    - Review comments: inline diff comments tied to a specific file and line.
+
+    Args:
+        pr_number: The pull request number.
+
+    Returns:
+        Formatted string of all comments with author, timestamp, and body.
+    """
+    try:
+        # --- Issue-level comments (general PR thread) ---
+        raw_issue = _run_gh([
+            "api",
+            f"repos/{{owner}}/{{repo}}/issues/{pr_number}/comments",
+            "--paginate",
+        ])
+        issue_comments = json.loads(raw_issue)
+
+        # --- Review comments (inline diff comments) ---
+        raw_review = _run_gh([
+            "api",
+            f"repos/{{owner}}/{{repo}}/pulls/{pr_number}/comments",
+            "--paginate",
+        ])
+        review_comments = json.loads(raw_review)
+
+        if not issue_comments and not review_comments:
+            return f"PR #{pr_number} has no comments."
+
+        lines = [f"Comments on PR #{pr_number}:"]
+
+        if issue_comments:
+            lines.append(f"\n--- General Comments ({len(issue_comments)}) ---")
+            for c in issue_comments:
+                author = c.get("user", {}).get("login", "unknown")
+                created_at = c.get("created_at", "N/A")
+                updated_at = c.get("updated_at", "N/A")
+                body = c.get("body", "").strip()
+                lines.append(
+                    f"\n[{author}] {created_at}"
+                    + (f" (updated: {updated_at})" if updated_at != created_at else "")
+                )
+                lines.append(body)
+
+        if review_comments:
+            lines.append(f"\n--- Inline Review Comments ({len(review_comments)}) ---")
+            for c in review_comments:
+                author = c.get("user", {}).get("login", "unknown")
+                created_at = c.get("created_at", "N/A")
+                updated_at = c.get("updated_at", "N/A")
+                path = c.get("path", "unknown")
+                line = c.get("line") or c.get("original_line", "N/A")
+                diff_hunk = c.get("diff_hunk", "")
+                body = c.get("body", "").strip()
+                lines.append(
+                    f"\n[{author}] {created_at}"
+                    + (f" (updated: {updated_at})" if updated_at != created_at else "")
+                )
+                lines.append(f"  File: {path}  Line: {line}")
+                if diff_hunk:
+                    # Show only the last few lines of the hunk for context
+                    hunk_lines = diff_hunk.splitlines()
+                    snippet = (
+                        "\n".join(hunk_lines[-5:])
+                        if len(hunk_lines) > 5
+                        else diff_hunk
+                    )
+                    lines.append(f"  Diff context:\n{snippet}")
+                lines.append(body)
+
+        return "\n".join(lines)
+
+    except Exception as e:
+        return f"Error getting comments for PR #{pr_number}: {e}"


### PR DESCRIPTION
…/view/get_comments

- Extract _run_gh helper into gh_utils.py to share across tool modules
- Add pr_get_comments to pr_review_tools.py: fetches both general and inline review comments with author, timestamp, file path, line number
- Add pr_create_tool.py with submit_pull_request: creates PR via gh CLI, defaults to draft=True for safety
- Add issue_tools.py with issue_list, issue_view, issue_get_comments: list/view issues and read full comment history
- Register all new tools in __init__.py all_tools list