### PR TITLE
feat: config.yaml で system_prompt_markdown_path によるカスタムシステムプロンプトを指定可能にする

### DIFF
--- a/src/tokuye/agent/strands_agent.py
+++ b/src/tokuye/agent/strands_agent.py
@@ -7,7 +7,7 @@ from strands.agent.conversation_manager import SummarizingConversationManager
 from strands.models import BedrockModel
 from strands.session.file_session_manager import FileSessionManager
 from strands.types.event_loop import Usage
-from tokuye.prompts.prompt_loader import load_prompt, load_prompt_if_exists
+from tokuye.prompts.prompt_loader import load_custom_system_prompt, load_prompt, load_prompt_if_exists
 from tokuye.mcp import MCPClientManager
 from tokuye.tools.strands_tools import all_tools
 from tokuye.tools.strands_tools.phase_tool import configure_phase_models
@@ -32,11 +32,21 @@ class StrandsAgent:
         self.add_system_message = add_system_message
         self.set_thinking = set_thinking
         self.update_token_usage = update_token_usage
-        if settings.language == "ja":
+        if settings.system_prompt_markdown_path:
+            self.system_prompt = load_custom_system_prompt(
+                settings.system_prompt_markdown_path
+            )
+            logger.info(
+                "Using custom system prompt: %s",
+                settings.system_prompt_markdown_path,
+            )
+        elif settings.language == "ja":
             self.system_prompt = load_prompt("system_prompt.md")
-            self.summary_prompt = load_prompt_if_exists("summary_prompt.md")
         elif settings.language == "en":
             self.system_prompt = load_prompt("system_prompt_en.md")
+        if settings.language == "ja":
+            self.summary_prompt = load_prompt_if_exists("summary_prompt.md")
+        else:
             self.summary_prompt = load_prompt_if_exists("summary_prompt_en.md")
 
         # --- Model setup -------------------------------------------------

--- a/src/tokuye/prompts/prompt_loader.py
+++ b/src/tokuye/prompts/prompt_loader.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from collections import defaultdict
 
 from tokuye.utils.config import settings
 
@@ -77,3 +78,66 @@ def load_prompt_if_exists(prompt_file: str) -> str:
 
     # Use normal load_prompt if it exists
     return load_prompt(prompt_file)
+
+
+def load_custom_system_prompt(path: str) -> str:
+    """
+    Load a custom system prompt from an arbitrary file path.
+
+    The path is resolved as follows:
+      - If absolute, used as-is.
+      - If relative, resolved against ``settings.project_root``.
+
+    Variable substitution (``{project_root}``, ``{title}``,
+    ``{optional_name_rule}``) is applied the same way as :func:`load_prompt`,
+    but unknown placeholders are left intact instead of raising ``KeyError``.
+
+    Args:
+        path: Absolute or project-root-relative path to the markdown file.
+
+    Returns:
+        str: Prompt string with variables replaced.
+
+    Raises:
+        FileNotFoundError: If the file does not exist.
+    """
+    resolved = Path(path)
+    if not resolved.is_absolute():
+        resolved = Path(settings.project_root) / resolved
+
+    if not resolved.exists():
+        raise FileNotFoundError(
+            f"Custom system prompt file not found: {resolved}"
+        )
+
+    with open(resolved, "r", encoding="utf-8") as f:
+        prompt = f.read()
+
+    if settings.language == "ja":
+        if settings.name:
+            title = f"# {settings.name} - AI開発支援エージェント"
+            optional_name_rule = (
+                f"以後、あなたは自分を {settings.name} として扱う。\n"
+                "ただし、ユーザーへの返答で毎回名乗る必要はない（自然に振る舞う）。"
+            )
+        else:
+            title = "# AI開発支援エージェント"
+            optional_name_rule = ""
+    else:
+        if settings.name:
+            title = f"# {settings.name} - AI Development Support Agent"
+            optional_name_rule = (
+                f"From now on, you will treat yourself as {settings.name}.\n"
+                "However, you do not need to introduce yourself by name in every reply (behave naturally)."
+            )
+        else:
+            title = "# AI Development Support Agent"
+            optional_name_rule = ""
+
+    # Use format_map with a defaultdict so unknown placeholders are left intact
+    variables = defaultdict(lambda: "{unknown}", {
+        "project_root": str(settings.project_root),
+        "title": title,
+        "optional_name_rule": optional_name_rule,
+    })
+    return prompt.format_map(variables)

--- a/src/tokuye/utils/config.py
+++ b/src/tokuye/utils/config.py
@@ -42,6 +42,8 @@ class Settings(BaseSettings):
     pr_branch_prefix: str = "tokuye/"
     max_steps: int = 100
 
+    system_prompt_markdown_path: Optional[str] = ""
+
     strands_session_dir: str = "sessions"
 
     class Config:
@@ -125,6 +127,7 @@ def _apply_yaml_to_settings(
         "pr_branch_prefix",
         "strands_session_dir",
         "name",
+        "system_prompt_markdown_path",
         "theme",
     ]
     for key in simple_keys:


### PR DESCRIPTION
## 概要

`config.yaml` に `system_prompt_markdown_path` を追加し、任意の Markdown ファイルをシステムプロンプトとして使えるようにする。

## 背景

デフォルトのシステムプロンプト（`system_prompt.md` / `system_prompt_en.md`）をプロジェクトごとにカスタマイズしたいというニーズに対応する。

## 変更内容

### `src/tokuye/utils/config.py`
- `Settings` に `system_prompt_markdown_path: Optional[str] = ""` を追加
- `_apply_yaml_to_settings` の `simple_keys` に追加し、`config.yaml` から読み込めるようにする

### `src/tokuye/prompts/prompt_loader.py`
- `load_custom_system_prompt(path: str) -> str` を新設
  - 相対パスは `project_root` 基準で解決、絶対パスはそのまま使用
  - `{project_root}` / `{title}` / `{optional_name_rule}` の変数置換を適用
  - 未知のプレースホルダーは `KeyError` にならず `{unknown}` に置換（`format_map` + `defaultdict`）
  - ファイルが存在しない場合は `FileNotFoundError` を送出

### `src/tokuye/agent/strands_agent.py`
- `system_prompt_markdown_path` が設定されていれば `load_custom_system_prompt` を優先して呼び出す
- 未設定なら従来通り `language` に応じたデフォルトプロンプトを使用
- `summary_prompt` の読み込みは `system_prompt_markdown_path` の有無に関わらず `language` で決定（既存挙動を維持）

## 使い方

```yaml
# .tokuye/config.yaml
system_prompt_markdown_path: "prompts/my_system_prompt.md"
```

- 相対パスの場合は `<project_root>/prompts/my_system_prompt.md` を読みに行く
- 絶対パスも使用可能
- 未設定（空文字）の場合は従来と完全に同じ動作

## 動作確認

- 起動ログに `Using custom system prompt: <path>` が出ればカスタムプロンプトが読み込まれている
- 存在しないパスを指定すると `FileNotFoundError` で即座にエラーになる（意図的）

## 破壊的変更

なし。`system_prompt_markdown_path` を設定しない限り既存の動作は変わらない。
