### PR TITLE
feat: Mistral Devstral 2 (devstral-2) モデル対応

### DIFF
--- a/src/tokuye/main.py
+++ b/src/tokuye/main.py
@@ -51,6 +51,8 @@ def main(
         settings.model_identifier = "haiku-4-5"
     if "claude-opus-4-6-" in settings.bedrock_model_id:
         settings.model_identifier = "opus-4-6"
+    if "devstral-2" in settings.bedrock_model_id:
+        settings.model_identifier = "devstral-2"
 
     if settings.bedrock_plan_model_id:
         if "claude-sonnet-4-6" in settings.bedrock_plan_model_id:
@@ -59,6 +61,8 @@ def main(
             settings.plan_model_identifier = "haiku-4-5"
         if "claude-opus-4-6-" in settings.bedrock_plan_model_id:
             settings.plan_model_identifier = "opus-4-6"
+        if "devstral-2" in settings.bedrock_plan_model_id:
+            settings.plan_model_identifier = "devstral-2"
 
     validate_settings()
     token_tracker.set_cost_table()

--- a/src/tokuye/utils/config.py
+++ b/src/tokuye/utils/config.py
@@ -212,5 +212,5 @@ def validate_settings():
     if settings.model_identifier == "":
         raise ValueError(
             "model_identifier must be specified. Supported models are: "
-            "Claude Sonnet 4.6, Claude Haiku 4.5, Claude Opus 4.6."
+            "Claude Sonnet 4.6, Claude Haiku 4.5, Claude Opus 4.6, Mistral Devstral 2."
         )

--- a/src/tokuye/utils/token_tracker.py
+++ b/src/tokuye/utils/token_tracker.py
@@ -23,6 +23,10 @@ MODEL_COST = {
         "cache_write": 0.00625,
         "cache_read": 0.0005,
     },
+    "devstral-2": {
+        "input": 0.00048,
+        "output": 0.0024,
+    },
 }
 
 
@@ -130,8 +134,8 @@ class TokenUsageTracker:
             call_cost_usd = (
                 self.calculate_cost(input_tokens, table["input"])
                 + self.calculate_cost(output_tokens, table["output"])
-                + self.calculate_cost(cache_creation, table["cache_write"])
-                + self.calculate_cost(cache_read, table["cache_read"])
+                + self.calculate_cost(cache_creation, table.get("cache_write", 0.0))
+                + self.calculate_cost(cache_read, table.get("cache_read", 0.0))
             )
             self._current_turn_cost_usd += call_cost_usd
             self._session_cost_usd += call_cost_usd


### PR DESCRIPTION
## 概要

Bedrock 上の `mistral.devstral-2-123b` を利用できるようにする。

## 背景

- Claude シリーズのコストを抑えるため、Bedrock で利用可能な Mistral Devstral 2 への対応が必要
- 既存コードはキャッシュキー (`cache_write` / `cache_read`) を無条件参照しており、キャッシュなしモデルで KeyError が発生する問題があった

## 変更内容

| ファイル | 変更内容 |
|---------|---------|
| `src/tokuye/utils/token_tracker.py` | `MODEL_COST` に `devstral-2` エントリ追加（input: $0.00048/1k, output: $0.0024/1k、cache キーなし） |
| `src/tokuye/utils/token_tracker.py` | `add_usage()` の `cache_write`/`cache_read` 参照を `.get(..., 0.0)` に変更し、キャッシュなしモデルでも KeyError にならないよう修正 |
| `src/tokuye/main.py` | `devstral-2` の `model_identifier` 検出分岐を追加（`bedrock_model_id` / `bedrock_plan_model_id` 両方） |
| `src/tokuye/utils/config.py` | `validate_settings()` のエラーメッセージに Mistral Devstral 2 を追記 |

## 使い方

`.env` または設定ファイルで以下を指定：

```
bedrock_model_id = mistral.devstral-2-123b
```

## 影響範囲・リスク

- `.get()` 化は既存の Claude モデルにも適用されるが、Claude のコストテーブルにはキーが存在するため動作変化なし
- 既存モデルの回帰リスク：なし
