### PR TITLE
fix: Devstralなどキャッシュ非対応モデルでprompt cacheを無効化

### DIFF
--- a/src/tokuye/agent/strands_agent.py
+++ b/src/tokuye/agent/strands_agent.py
@@ -17,6 +17,14 @@ from tokuye.utils.token_tracker import token_tracker
 logger = logging.getLogger(__name__)
 
 
+def _supports_prompt_cache(model_id: str) -> bool:
+    """Return True if the model supports Bedrock prompt caching.
+
+    Currently only Anthropic (Claude) models support prompt caching on Bedrock.
+    """
+    return "anthropic" in model_id.lower()
+
+
 class MaxStepsException(Exception):
 
     def __init__(self, message: str):
@@ -51,9 +59,12 @@ class StrandsAgent:
 
         # --- Model setup -------------------------------------------------
         # The "executing" model is always the primary bedrock_model_id.
+        _exec_cache = _supports_prompt_cache(settings.bedrock_model_id)
         self.model = BedrockModel(
-            cache_prompt="default",
-            cache_tools="default",
+            **({
+                "cache_prompt": "default",
+                "cache_tools": "default",
+            } if _exec_cache else {}),
             model_id=settings.bedrock_model_id,
             temperature=settings.model_temperature,
         )
@@ -61,9 +72,12 @@ class StrandsAgent:
         # When bedrock_plan_model_id is configured, create a separate
         # "thinking" model and wire up the phase-switching tool.
         if settings.bedrock_plan_model_id:
+            _plan_cache = _supports_prompt_cache(settings.bedrock_plan_model_id)
             thinking_model = BedrockModel(
-                cache_prompt="default",
-                cache_tools="default",
+                **({
+                    "cache_prompt": "default",
+                    "cache_tools": "default",
+                } if _plan_cache else {}),
                 model_id=settings.bedrock_plan_model_id,
                 temperature=settings.model_temperature,
             )


### PR DESCRIPTION
## 問題

Devstral（Mistral系）を使用すると以下のエラーが発生していた。

```
An unexpected error occurred. (An error occurred (AccessDeniedException) when calling the ConverseStream operation: You invoked an unsupported model or your request did not allow prompt caching. See the documentation for more information.)
```

## 原因

`BedrockModel` 生成時に、モデルIDに関係なく常に `cache_prompt="default"` / `cache_tools="default"` を渡していた。Bedrock の Prompt Caching は現状 Anthropic (Claude) モデルのみサポートしており、Devstral では `AccessDeniedException` が発生する。

## 修正内容

`_supports_prompt_cache(model_id: str) -> bool` を追加し、model_id に `"anthropic"` が含まれる場合のみキャッシュオプションを渡すよう変更。

- executing モデル・thinking モデル（`bedrock_plan_model_id`）の両方に適用
- Claude モデルの動作は変わらない

## 変更ファイル

- `src/tokuye/agent/strands_agent.py`

## 検証方法

- Devstral で起動してチャットが通ること（`AccessDeniedException` が出なくなること）
- Claude モデルで起動してキャッシュが引き続き効いていること（トークン表示に `cache_read` が出ること）
