### PR TITLE
feat: Amazon Nova Pro モデル対応を追加

### DIFF
--- a/src/tokuye/agent/strands_agent.py
+++ b/src/tokuye/agent/strands_agent.py
@@ -20,9 +20,10 @@ logger = logging.getLogger(__name__)
 def _supports_prompt_cache(model_id: str) -> bool:
     """Return True if the model supports Bedrock prompt caching.
 
-    Currently only Anthropic (Claude) models support prompt caching on Bedrock.
+    Currently Anthropic (Claude) models and Amazon Nova Pro support prompt
+    caching on Bedrock.
     """
-    return "anthropic" in model_id.lower()
+    return "anthropic" in model_id.lower() or "nova-pro-v1" in model_id.lower()
 
 
 class MaxStepsException(Exception):

--- a/src/tokuye/main.py
+++ b/src/tokuye/main.py
@@ -53,6 +53,8 @@ def main(
         settings.model_identifier = "opus-4-6"
     if "devstral-2" in settings.bedrock_model_id:
         settings.model_identifier = "devstral-2"
+    if "nova-pro-v1" in settings.bedrock_model_id:
+        settings.model_identifier = "nova-pro"
 
     if settings.bedrock_plan_model_id:
         if "claude-sonnet-4-6" in settings.bedrock_plan_model_id:
@@ -63,6 +65,8 @@ def main(
             settings.plan_model_identifier = "opus-4-6"
         if "devstral-2" in settings.bedrock_plan_model_id:
             settings.plan_model_identifier = "devstral-2"
+        if "nova-pro-v1" in settings.bedrock_plan_model_id:
+            settings.plan_model_identifier = "nova-pro"
 
     validate_settings()
     token_tracker.set_cost_table()

--- a/src/tokuye/utils/config.py
+++ b/src/tokuye/utils/config.py
@@ -212,5 +212,5 @@ def validate_settings():
     if settings.model_identifier == "":
         raise ValueError(
             "model_identifier must be specified. Supported models are: "
-            "Claude Sonnet 4.6, Claude Haiku 4.5, Claude Opus 4.6, Mistral Devstral 2."
+            "Claude Sonnet 4.6, Claude Haiku 4.5, Claude Opus 4.6, Mistral Devstral 2, Amazon Nova Pro."
         )

--- a/src/tokuye/utils/token_tracker.py
+++ b/src/tokuye/utils/token_tracker.py
@@ -27,6 +27,12 @@ MODEL_COST = {
         "input": 0.00048,
         "output": 0.0024,
     },
+    "nova-pro": {
+        "input": 0.00096,
+        "output": 0.00384,
+        "cache_write": 0.00096,  # Actual price unknown; using input price as placeholder
+        "cache_read": 0.00096,   # Actual price unknown; using input price as placeholder
+    },
 }
 
 


### PR DESCRIPTION
## 概要

対応モデルに Amazon Nova Pro を追加する。

`bedrock_model_id` に `nova-pro-v1` が含まれる場合、`model_identifier` を `nova-pro` として扱う。

## 変更内容

### `src/tokuye/utils/token_tracker.py`
- `MODEL_COST` に `nova-pro` エントリを追加
  - input: `$0.00096` / 1k tokens
  - output: `$0.00384` / 1k tokens
  - cache_write / cache_read: 実際の料金が不明なため、暫定で input と同値 (`$0.00096`) を設定

### `src/tokuye/agent/strands_agent.py`
- `_supports_prompt_cache()` に Nova Pro の判定を追加
  - `"nova-pro-v1" in model_id` の場合も `True` を返すよう変更

### `src/tokuye/main.py`
- `bedrock_model_id` / `bedrock_plan_model_id` の両方に `nova-pro-v1` → `nova-pro` の identifier 解決ロジックを追加

### `src/tokuye/utils/config.py`
- `validate_settings()` のエラーメッセージにサポートモデルとして Nova Pro を追記

## 備考

- キャッシュ料金（`cache_write` / `cache_read`）は公式情報が見つからないため暫定値。判明次第 `token_tracker.py` の該当箇所を更新すること。
