### PR TITLE
fix: Nova モデルで cache_tools を無効化し ValidationException を修正

### DIFF
--- a/src/tokuye/agent/strands_agent.py
+++ b/src/tokuye/agent/strands_agent.py
@@ -26,6 +26,16 @@ def _supports_prompt_cache(model_id: str) -> bool:
     return "anthropic" in model_id.lower() or "nova-pro-v1" in model_id.lower()
 
 
+def _supports_tool_cache(model_id: str) -> bool:
+    """Return True if the model supports caching tool definitions on Bedrock.
+
+    Nova models only support message-level caching; tool-level caching
+    (cachePoint in toolConfig) is not permitted and causes a ValidationException.
+    Only Anthropic (Claude) models support cache_tools.
+    """
+    return "anthropic" in model_id.lower()
+
+
 class MaxStepsException(Exception):
 
     def __init__(self, message: str):
@@ -66,11 +76,10 @@ class StrandsAgent:
         # --- Model setup -------------------------------------------------
         # The "executing" model is always the primary bedrock_model_id.
         _exec_cache = _supports_prompt_cache(settings.bedrock_model_id)
+        _exec_tool_cache = _supports_tool_cache(settings.bedrock_model_id)
         self.model = BedrockModel(
-            **({
-                "cache_prompt": "default",
-                "cache_tools": "default",
-            } if _exec_cache else {}),
+            **({"cache_prompt": "default"} if _exec_cache else {}),
+            **({"cache_tools": "default"} if _exec_tool_cache else {}),
             model_id=settings.bedrock_model_id,
             temperature=settings.model_temperature,
         )
@@ -79,11 +88,10 @@ class StrandsAgent:
         # "thinking" model and wire up the phase-switching tool.
         if settings.bedrock_plan_model_id:
             _plan_cache = _supports_prompt_cache(settings.bedrock_plan_model_id)
+            _plan_tool_cache = _supports_tool_cache(settings.bedrock_plan_model_id)
             thinking_model = BedrockModel(
-                **({
-                    "cache_prompt": "default",
-                    "cache_tools": "default",
-                } if _plan_cache else {}),
+                **({"cache_prompt": "default"} if _plan_cache else {}),
+                **({"cache_tools": "default"} if _plan_tool_cache else {}),
                 model_id=settings.bedrock_plan_model_id,
                 temperature=settings.model_temperature,
             )


### PR DESCRIPTION
## 問題

Nova モデルを使用すると以下のエラーが発生していた。

```
An unexpected error occurred. (An error occurred (ValidationException) when calling the ConverseStream operation: The model returned the following errors: Malformed input request: #/toolConfig/tools/30: extraneous key [cachePoint] is not permitted, please reformat your input and try again.)
```

## 原因

`_supports_prompt_cache()` が Nova Pro で `True` を返すため、`cache_tools: "default"` も一緒に `BedrockModel` に渡されていた。

Nova モデルはメッセージレベルのキャッシュ（`cache_prompt`）のみサポートしており、ツール定義へのキャッシュポイント挿入（`cache_tools` / `cachePoint` in `toolConfig`）は許可されていない。

## 修正内容

`_supports_tool_cache()` を追加し、`cache_prompt` と `cache_tools` の可否を独立して管理するよう変更。

| モデル | `cache_prompt` | `cache_tools` |
|---|---|---|
| Anthropic (Claude) | ✅ | ✅ |
| Amazon Nova Pro | ✅ | ❌ |
| その他 | ❌ | ❌ |

## 変更ファイル

- `src/tokuye/agent/strands_agent.py`
  - `_supports_tool_cache()` 関数を追加
  - exec model・plan model 両方の `BedrockModel` 生成を `cache_prompt` / `cache_tools` で独立制御

## 既存への影響

Claude の動作は変わらない（両方有効のまま）。
