### PR TITLE
feat: AWS Bedrock アプリケーション推論プロファイル対応

### DIFF
--- a/src/tokuye/agent/strands_agent.py
+++ b/src/tokuye/agent/strands_agent.py
@@ -17,23 +17,24 @@ from tokuye.utils.token_tracker import token_tracker
 logger = logging.getLogger(__name__)
 
 
-def _supports_prompt_cache(model_id: str) -> bool:
+def _supports_prompt_cache(model_identifier: str) -> bool:
     """Return True if the model supports Bedrock prompt caching.
 
-    Currently Anthropic (Claude) models and Amazon Nova Pro support prompt
-    caching on Bedrock.
+    Determined by model_identifier (the normalised internal name), not the
+    raw model_id / ARN.  Claude models and Amazon Nova Pro support prompt
+    caching; Mistral Devstral does not.
     """
-    return "anthropic" in model_id.lower() or "nova-pro-v1" in model_id.lower()
+    return model_identifier in ("sonnet-4-6", "haiku-4-5", "opus-4-6", "nova-pro")
 
 
-def _supports_tool_cache(model_id: str) -> bool:
+def _supports_tool_cache(model_identifier: str) -> bool:
     """Return True if the model supports caching tool definitions on Bedrock.
 
-    Nova models only support message-level caching; tool-level caching
-    (cachePoint in toolConfig) is not permitted and causes a ValidationException.
-    Only Anthropic (Claude) models support cache_tools.
+    Determined by model_identifier.  Nova models only support message-level
+    caching; tool-level caching (cachePoint in toolConfig) causes a
+    ValidationException.  Only Claude models support cache_tools.
     """
-    return "anthropic" in model_id.lower()
+    return model_identifier in ("sonnet-4-6", "haiku-4-5", "opus-4-6")
 
 
 class MaxStepsException(Exception):
@@ -75,8 +76,8 @@ class StrandsAgent:
 
         # --- Model setup -------------------------------------------------
         # The "executing" model is always the primary bedrock_model_id.
-        _exec_cache = _supports_prompt_cache(settings.bedrock_model_id)
-        _exec_tool_cache = _supports_tool_cache(settings.bedrock_model_id)
+        _exec_cache = _supports_prompt_cache(settings.model_identifier)
+        _exec_tool_cache = _supports_tool_cache(settings.model_identifier)
         self.model = BedrockModel(
             **({"cache_prompt": "default"} if _exec_cache else {}),
             **({"cache_tools": "default"} if _exec_tool_cache else {}),
@@ -87,8 +88,8 @@ class StrandsAgent:
         # When bedrock_plan_model_id is configured, create a separate
         # "thinking" model and wire up the phase-switching tool.
         if settings.bedrock_plan_model_id:
-            _plan_cache = _supports_prompt_cache(settings.bedrock_plan_model_id)
-            _plan_tool_cache = _supports_tool_cache(settings.bedrock_plan_model_id)
+            _plan_cache = _supports_prompt_cache(settings.plan_model_identifier)
+            _plan_tool_cache = _supports_tool_cache(settings.plan_model_identifier)
             thinking_model = BedrockModel(
                 **({"cache_prompt": "default"} if _plan_cache else {}),
                 **({"cache_tools": "default"} if _plan_tool_cache else {}),

--- a/src/tokuye/main.py
+++ b/src/tokuye/main.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import typer
 
 from tokuye.textual.base_interface import ChatInterface
-from tokuye.utils.config import load_yaml_config, settings, validate_settings
+from tokuye.utils.config import load_yaml_config, settings, validate_settings, _resolve_source_model_id
 from tokuye.utils.token_tracker import token_tracker
 
 os.environ["BYPASS_TOOL_CONSENT"] = "true"
@@ -45,27 +45,29 @@ def main(
     settings.language = language
     load_yaml_config(settings)
 
-    if "claude-sonnet-4-6" in settings.bedrock_model_id:
+    _exec_source = _resolve_source_model_id(settings.bedrock_model_id)
+    if "claude-sonnet-4-6" in _exec_source:
         settings.model_identifier = "sonnet-4-6"
-    if "claude-haiku-4-5-" in settings.bedrock_model_id:
+    if "claude-haiku-4-5-" in _exec_source:
         settings.model_identifier = "haiku-4-5"
-    if "claude-opus-4-6-" in settings.bedrock_model_id:
+    if "claude-opus-4-6-" in _exec_source:
         settings.model_identifier = "opus-4-6"
-    if "devstral-2" in settings.bedrock_model_id:
+    if "devstral-2" in _exec_source:
         settings.model_identifier = "devstral-2"
-    if "nova-pro-v1" in settings.bedrock_model_id:
+    if "nova-pro-v1" in _exec_source:
         settings.model_identifier = "nova-pro"
 
     if settings.bedrock_plan_model_id:
-        if "claude-sonnet-4-6" in settings.bedrock_plan_model_id:
+        _plan_source = _resolve_source_model_id(settings.bedrock_plan_model_id)
+        if "claude-sonnet-4-6" in _plan_source:
             settings.plan_model_identifier = "sonnet-4-6"
-        if "claude-haiku-4-5-" in settings.bedrock_plan_model_id:
+        if "claude-haiku-4-5-" in _plan_source:
             settings.plan_model_identifier = "haiku-4-5"
-        if "claude-opus-4-6-" in settings.bedrock_plan_model_id:
+        if "claude-opus-4-6-" in _plan_source:
             settings.plan_model_identifier = "opus-4-6"
-        if "devstral-2" in settings.bedrock_plan_model_id:
+        if "devstral-2" in _plan_source:
             settings.plan_model_identifier = "devstral-2"
-        if "nova-pro-v1" in settings.bedrock_plan_model_id:
+        if "nova-pro-v1" in _plan_source:
             settings.plan_model_identifier = "nova-pro"
 
     validate_settings()

--- a/src/tokuye/utils/config.py
+++ b/src/tokuye/utils/config.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import re
+import boto3
 from pathlib import Path
 from typing import Dict, List, Optional
 
@@ -195,6 +196,43 @@ def load_yaml_config(settings_instance: Settings) -> Settings:  # noqa: C901
 
 
 settings = Settings()
+
+
+def _resolve_source_model_id(model_id: str) -> str:
+    """Return the underlying foundation-model ID for an application inference profile.
+
+    If *model_id* is the ARN of an application inference profile
+    (``…:application-inference-profile/<id>``), call ``GetInferenceProfile``
+    and return the ARN of the first source model so that the caller can
+    perform normal model-name matching against it.
+
+    For any other value (plain model ID, system-defined inference profile ARN,
+    cross-region profile ID, …) the input is returned unchanged.
+    """
+    if "application-inference-profile/" not in model_id:
+        return model_id
+
+    try:
+        client = boto3.client("bedrock")
+        response = client.get_inference_profile(
+            inferenceProfileIdentifier=model_id
+        )
+        models = response.get("models", [])
+        if models:
+            return models[0]["modelArn"]
+        logger.warning(
+            "GetInferenceProfile returned no models for %r; "
+            "model_identifier will not be resolved",
+            model_id,
+        )
+    except Exception as exc:
+        raise RuntimeError(
+            f"Failed to resolve application inference profile {model_id!r}. "
+            "Make sure the ARN is correct and the IAM role has "
+            "'bedrock:GetInferenceProfile' permission."
+        ) from exc
+
+    return model_id
 
 
 def validate_settings():


### PR DESCRIPTION
## 概要

AWS Bedrock のアプリケーション推論プロファイル（Application Inference Profile）を `bedrock_model_id` および `bedrock_plan_model_id` に指定できるようにする。

アプリケーション推論プロファイルの ARN（例: `arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/hoge12fu34`）を設定した場合、従来の文字列マッチが外れて `model_identifier` が空のまま起動時バリデーションで弾かれていた問題を修正する。

## 変更内容

### `src/tokuye/utils/config.py`
- `_resolve_source_model_id(model_id: str) -> str` を追加
  - `application-inference-profile/` を含む ARN の場合、`GetInferenceProfile` API を呼んで `models[0]["modelArn"]`（sourceModel の ARN）を返す
  - それ以外はそのまま素通し
  - API 呼び出し失敗時は `RuntimeError` で明示的に落とし、必要な IAM 権限をメッセージに含める

### `src/tokuye/main.py`
- `bedrock_model_id` / `bedrock_plan_model_id` の両方を `_resolve_source_model_id()` に通してから既存の文字列マッチを実行
- `bedrock_model_id` / `bedrock_plan_model_id` 自体は変更しない（Bedrock API 呼び出しには元の ARN を使い続ける）

### `src/tokuye/agent/strands_agent.py`
- `_supports_prompt_cache` / `_supports_tool_cache` の判定を `model_id` の文字列マッチ → `model_identifier` の値比較に変更
  - アプリケーション推論プロファイルの ARN が渡されても正しく判定できるようになる
  - 判定ロジックが明示的な識別子リストになり可読性も向上
- 呼び出し箇所を `settings.bedrock_model_id` → `settings.model_identifier`、`settings.bedrock_plan_model_id` → `settings.plan_model_identifier` に変更

## 動作確認方法

```bash
# 通常の model_id（既存動作が壊れていないか）
BEDROCK_MODEL_ID=global.anthropic.claude-sonnet-4-6 tokuye --project-root .

# アプリケーション推論プロファイル ARN（exec model）
BEDROCK_MODEL_ID=arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/hoge12fu34 tokuye --project-root .

# アプリケーション推論プロファイル ARN（plan model も）
BEDROCK_MODEL_ID=arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/hoge12fu34 \
BEDROCK_PLAN_MODEL_ID=arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/fuga56ab78 \
tokuye --project-root .
```

## 注意事項

- `bedrock:GetInferenceProfile` IAM 権限が必要。ない場合は起動時に `RuntimeError` で明示的に落ちる
- `GetInferenceProfile` の呼び出しは起動時1回のみ（exec / plan それぞれ最大1回）
- 既存の通常 model_id を使っているユーザーの動作は一切変わらない
