### PR TITLE
fix: state_machine_mode で load_prompt が KeyError になる問題を修正

### DIFF
--- a/src/tokuye/prompts/prompt_loader.py
+++ b/src/tokuye/prompts/prompt_loader.py
@@ -48,11 +48,14 @@ def load_prompt(prompt_file: str) -> str:
             optional_name_rule = ""
 
     # Replace configuration variables
-    prompt = prompt.format(
-        project_root=settings.project_root,
-        title=title,
-        optional_name_rule=optional_name_rule,
-    )
+    # Use format_map with a defaultdict so unknown placeholders (e.g. JSON
+    # examples in prompt files) are left intact instead of raising KeyError.
+    variables = defaultdict(lambda key: "{" + key + "}", {
+        "project_root": str(settings.project_root),
+        "title": title,
+        "optional_name_rule": optional_name_rule,
+    })
+    prompt = prompt.format_map(variables)
 
     return prompt
 


### PR DESCRIPTION
## 問題

`state_machine_mode` 有効時、`load_prompt` で読み込む `state_classifier_prompt.md` 等に JSON 例示（`{"next_state": "STATE_NAME"}` など）が含まれており、`prompt.format()` が未知キーとして解釈して `KeyError` を起こしていた。

## 原因

`load_prompt` が `prompt.format(project_root=..., title=..., optional_name_rule=...)` を使っており、辞書に存在しないキーがあると `KeyError` になる。

## 修正

`load_custom_system_prompt` と同様に `format_map` + `defaultdict` を使う方式に変更。

```python
# Before
prompt = prompt.format(
    project_root=settings.project_root,
    title=title,
    optional_name_rule=optional_name_rule,
)

# After
variables = defaultdict(lambda key: "{" + key + "}", {
    "project_root": str(settings.project_root),
    "title": title,
    "optional_name_rule": optional_name_rule,
})
prompt = prompt.format_map(variables)
```

`project_root` / `title` / `optional_name_rule` 以外の `{...}` はそのまま素通りするため、既存の正常ケースへの影響なし。

## 影響範囲

- `src/tokuye/prompts/prompt_loader.py` の `load_prompt` のみ
- `load_prompt_if_exists` は `load_prompt` を呼ぶだけなので自動的に修正される
- `load_custom_system_prompt` は元々同方式のため変更不要
