### PR TITLE
fix: load_prompt の defaultdict lambda 引数エラーを修正

### DIFF
--- a/src/tokuye/prompts/prompt_loader.py
+++ b/src/tokuye/prompts/prompt_loader.py
@@ -1,7 +1,19 @@
 from pathlib import Path
-from collections import defaultdict
 
 from tokuye.utils.config import settings
+
+
+class _KeepUnknown(dict):
+    """dict subclass that leaves unknown format placeholders intact.
+
+    When ``str.format_map`` encounters a key not present in the mapping it
+    calls ``__missing__``.  Returning ``"{key}"`` causes the original
+    placeholder to be preserved in the output string instead of raising
+    ``KeyError``.
+    """
+
+    def __missing__(self, key: str) -> str:
+        return "{" + key + "}"
 
 
 def load_prompt(prompt_file: str) -> str:
@@ -48,9 +60,9 @@ def load_prompt(prompt_file: str) -> str:
             optional_name_rule = ""
 
     # Replace configuration variables
-    # Use format_map with a defaultdict so unknown placeholders (e.g. JSON
+    # Use format_map with _KeepUnknown so unknown placeholders (e.g. JSON
     # examples in prompt files) are left intact instead of raising KeyError.
-    variables = defaultdict(lambda key: "{" + key + "}", {
+    variables = _KeepUnknown({
         "project_root": str(settings.project_root),
         "title": title,
         "optional_name_rule": optional_name_rule,
@@ -137,8 +149,8 @@ def load_custom_system_prompt(path: str) -> str:
             title = "# AI Development Support Agent"
             optional_name_rule = ""
 
-    # Use format_map with a defaultdict so unknown placeholders are left intact
-    variables = defaultdict(lambda: "{unknown}", {
+    # Use format_map with _KeepUnknown so unknown placeholders are left intact
+    variables = _KeepUnknown({
         "project_root": str(settings.project_root),
         "title": title,
         "optional_name_rule": optional_name_rule,


### PR DESCRIPTION
## 問題

`load_prompt` 実行時に以下のエラーが発生していた。

```
TypeError: load_prompt.<locals>.<lambda>() missing 1 required positional argument: 'key'
```

## 原因

`defaultdict` のファクトリは **引数なし** の callable として呼ばれる（`factory()`）。  
しかし `lambda key: "{" + key + "}"` と引数ありで定義していたため、`format_map` が未知キーを参照した際に `TypeError` が発生していた。

`load_custom_system_prompt` の `lambda: "{unknown}"` は引数エラーは起きないが、未知キーが全て `"{unknown}"` に潰れるバグがあった。

## 修正

`__missing__` を実装した `_KeepUnknown` dict サブクラスを導入し、両関数の `defaultdict` を置き換えた。

```python
class _KeepUnknown(dict):
    def __missing__(self, key: str) -> str:
        return "{" + key + "}"
```

- `format_map` が未知キーを参照すると `__missing__` が呼ばれ、`{key}` をそのまま返す
- プロンプトファイル内の JSON 例示などの `{...}` プレースホルダーが壊れない
- 不要になった `from collections import defaultdict` を削除

## 変更ファイル

- `src/tokuye/prompts/prompt_loader.py`
