### PR TITLE
fix: state_classifier プロンプトの JSON 例で ValueError が発生する問題を修正

### DIFF
--- a/src/tokuye/prompts/state_classifier_prompt.md
+++ b/src/tokuye/prompts/state_classifier_prompt.md
@@ -66,7 +66,7 @@
 次のステートのみをJSON形式で返してください。説明は不要です。
 
 ```json
-{"next_state": "STATE_NAME"}
+{{"next_state": "STATE_NAME"}}
 ```
 
 STATE_NAME は上記のステート定義のいずれかです。

--- a/src/tokuye/prompts/state_classifier_prompt_en.md
+++ b/src/tokuye/prompts/state_classifier_prompt_en.md
@@ -66,7 +66,7 @@ You receive the current state and the user's message, and return the next state.
 Return only the next state as JSON. No explanation needed.
 
 ```json
-{"next_state": "STATE_NAME"}
+{{"next_state": "STATE_NAME"}}
 ```
 
 STATE_NAME must be one of the states defined above.


### PR DESCRIPTION
## 概要

`state_classifier_prompt.md` / `state_classifier_prompt_en.md` 内の JSON 出力例に含まれる `{...}` が `str.format_map` にフォーマット指定子として解釈され、`ValueError: Invalid format specifier` が発生していた問題を修正。

## 原因

```
{"next_state": "STATE_NAME"}
```

この行の `{` と `}` が `format_map` に食われ、`"next_state": "STATE_NAME"` がフォーマット指定子としてパースされる。  
`_KeepUnknown.__missing__` は `KeyError` しか補足できないため、パース自体が失敗する `ValueError` は素通りしていた。

## 修正内容

プロンプトファイル内の JSON 例を `{{...}}` にエスケープ。  
`format_map` は `{{` → `{`、`}}` → `}` に変換するため、LLM に渡る文字列は元通り `{"next_state": "STATE_NAME"}` になる。

```diff
-{"next_state": "STATE_NAME"}
+{{"next_state": "STATE_NAME"}}
```

## 変更ファイル

- `src/tokuye/prompts/state_classifier_prompt.md`
- `src/tokuye/prompts/state_classifier_prompt_en.md`

## 影響範囲

- コード変更なし
- LLM に渡るプロンプト内容は変化なし
- 他のプロンプトファイルに同様の問題がないことを確認済み
