### PR TITLE
fix: StateClassifier を BedrockModel.converse から Strands Agent に置き換え

### DIFF
--- a/src/tokuye/agent/state_machine.py
+++ b/src/tokuye/agent/state_machine.py
@@ -13,6 +13,7 @@ import json
 import logging
 from enum import Enum
 
+from strands import Agent
 from strands.models import BedrockModel
 
 from tokuye.prompts.prompt_loader import load_prompt
@@ -60,11 +61,16 @@ class StateClassifier:
     """
 
     def __init__(self, model: BedrockModel) -> None:
-        self._model = model
         if settings.language == "en":
             self._prompt = load_prompt("state_classifier_prompt_en.md")
         else:
             self._prompt = load_prompt("state_classifier_prompt.md")
+        self._agent = Agent(
+            model=model,
+            system_prompt=self._prompt,
+            tools=[],
+            callback_handler=None,
+        )
 
     def classify(self, current_state: DevState, user_message: str) -> DevState:
         """Return the next state synchronously."""
@@ -78,17 +84,11 @@ class StateClassifier:
                 f"現在のステート: {current_state.value}\n"
                 f"ユーザーの発言: {user_message}"
             )
-        messages = [{"role": "user", "content": user_content}]
         try:
-            response = self._model.converse(
-                system_prompt=self._prompt,
-                messages=messages,
-            )
-            # Extract text from the response
-            raw = ""
-            for block in response.get("output", {}).get("message", {}).get("content", []):
-                if "text" in block:
-                    raw += block["text"]
+            # Reset history to keep each classification stateless
+            self._agent.messages.clear()
+            result = self._agent(user_content)
+            raw = str(result)
 
             # Parse JSON
             # Strip markdown code fences if present


### PR DESCRIPTION
## 問題

`state_machine_mode` 有効時、`StateClassifier.classify` が `BedrockModel.converse()` を呼んでいたが、Strands SDK の `BedrockModel` にそのメソッドは存在しないためエラーになっていた。

## 原因

`BedrockModel` の公開 API は `stream`（async generator）のみ。`converse` は存在しない。

## 修正内容

`StateClassifier` を Strands の `Agent` を使う設計に刷新した。

- `__init__` で `Agent(model=model, system_prompt=..., tools=[], callback_handler=None)` を生成
- `classify` 内で `messages.clear()` → `self._agent(user_content)` → `str(result)` に置き換え
- 呼び出しごとに `messages.clear()` することでステートレスを保証（分類器に会話履歴は不要）
- JSON パース処理はそのまま流用

## 変更ファイル

- `src/tokuye/agent/state_machine.py` のみ

## 検証方法

`state_machine_mode: true` の設定で起動し、ユーザーメッセージを送信。ログに `StateClassifier: ... → ...` が出力されれば正常動作。