### PR TITLE
Add separate Bedrock model for repository description generation

### DIFF
--- a/src/tokuye/tools/strands_tools/repo_description.py
+++ b/src/tokuye/tools/strands_tools/repo_description.py
@@ -161,8 +161,9 @@ def generate_description_from_summary(summary_path: Path) -> str:
     with open(summary_path, "r", encoding="utf-8") as f:
         repo_summary = f.read()
 
+    repo_desc_model_id = settings.bedrock_repo_description_model_id or settings.bedrock_model_id
     model = BedrockModel(
-        model_id=settings.bedrock_model_id,
+        model_id=repo_desc_model_id,
         temperature=settings.model_temperature,
         streaming=False,
     )

--- a/src/tokuye/utils/config.py
+++ b/src/tokuye/utils/config.py
@@ -40,6 +40,8 @@ class Settings(BaseSettings):
     plan_model_identifier: str = ""
     bedrock_embedding_model_id: str = "amazon.titan-embed-text-v2:0"
 
+    bedrock_repo_description_model_id: str = ""  # repo-description生成用; 未指定時はbedrock_model_idにフォールバック
+    
     # --- State machine mode (v2) -----------------------------------------
     state_machine_mode: bool = False
     bedrock_impl_model_id: str = ""        # Developer node; falls back to bedrock_model_id
@@ -136,6 +138,7 @@ def _apply_yaml_to_settings(
         "bedrock_plan_model_id",
         "state_machine_mode",
         "bedrock_impl_model_id",
+        "bedrock_repo_description_model_id",
         "bedrock_classifier_model_id",
         "bedrock_pr_model_id",
         "model_temperature",


### PR DESCRIPTION
**Summary**
A new configuration field `bedrock_repo_description_model_id` has been added to the `Settings` class, allowing users to specify a separate Bedrock model for repository description generation. When this field is not set, the system falls back to the existing `bedrock_model_id` value, preserving full backward compatibility.

**Implementation Details**
- **`src/tokuye/utils/config.py`**:
  - Added `bedrock_repo_description_model_id: str = """ field to the `Settings` class
  - Added `"bedrock_repo_description_model_id"` to the `simple_keys` list in `_apply_yaml_to_settings` so the field is populated from YAML config

- **`src/tokuye/tools/strands_tools/repo_description.py`**:
  - In `generate_description_from_summary`, added logic to resolve the model ID: `repo_desc_model_id = settings.bedrock_repo_description_model_id or settings.bedrock_model_id`
  - Updated `BedrockModel` instantiation to use `repo_desc_model_id` instead of `settings.bedrock_model_id` directly

**Notes**
- **No breaking changes**: Default value of `""` means existing configurations continue to work without modification.
- **Fallback behavior**: If `bedrock_repo_description_model_id` is not set in config, the system silently falls back to `bedrock_model_id`.
- **No validation added**: `validate_settings` was intentionally not modified; no validation is enforced on this new field.
- **Testing instructions**: To test the new field, set `bedrock_repo_description_model_id` in the YAML config to a different model ID than `bedrock_model_id` and verify that repository description generation uses the specified model. To test fallback, leave the field unset and confirm behavior is unchanged.