### PR TITLE
修正: ファイル末尾の空行が失われる問題を修正

### DIFF
--- a/src/tokuye/tools/strands_tools/repo_summary_rag/data_loader.py
+++ b/src/tokuye/tools/strands_tools/repo_summary_rag/data_loader.py
@@ -66,6 +66,12 @@ def parse_repository(
         file_lines = file_text.splitlines()
         total_lines = total_lines_attr  # use the authoritative line count written by render_xml
 
+        # Pad file_text with newlines to match the original file's line count
+        if total_lines_attr > 0:
+            current_line_count = len(file_text.splitlines())
+            if current_line_count < total_lines_attr:
+                file_text += "\n" * (total_lines_attr - current_line_count)
+
         lang, segments = segment_code_by_path(file_text, file_path)  # List[CodeSegment]
         language = None
         if lang != "plain":


### PR DESCRIPTION
`data_loader.py` において、ファイル末尾の空行がセグメンターに渡す前に失われる問題を修正しました。

**変更の詳細:**
- `src/tokuye/tools/strands_tools/repo_summary_rag/data_loader.py`
  - `segment_code_by_path` 呼び出しの直前（68〜72行目）にパディング処理を追加
  - `total_lines_attr`（XMLの `lines` 属性値）が0より大きい場合のみ処理を実行
  - `file_text.splitlines()` で現在の行数を取得し、`total_lines_attr` との差分だけ `
` を末尾に追加
  - 既存の変数 `total_lines_attr` を再利用しており、他のロジックへの変更はなし

**注意事項:**
- **破壊的変更:** なし
- **マイグレーション手順:** N/A
- **既知の制限事項:** `total_lines_attr` が 0 の場合（XMLに `lines` 属性が存在しない・または0が設定されている場合）はパディングが適用されない
- **テスト手順:** 末尾に空行を含むファイルをRAGのデータソースとして処理し、セグメンターが返す行番号が元ファイルの行番号と一致することを確認する