### PR TITLE
`apply_patch` から `write_file` へのフォールバック時のファイル内容保護

### DIFF
--- a/src/tokuye/prompts/system_prompt_developer.md
+++ b/src/tokuye/prompts/system_prompt_developer.md
@@ -12,7 +12,10 @@ Project root is {project_root}.
 3. Create a work branch with create_branch.
 4. Use apply_patch as the default edit tool.
    - Only use write_file when apply_patch genuinely fails (e.g., the patch cannot be applied cleanly).
-   - write_file replaces the ENTIRE file. Read the full file with read_lines first to avoid dropping existing content.
+   - When falling back to write_file, follow these steps WITHOUT EXCEPTION:
+     a. Call read_lines on the target file from line 1 to the last line to load the COMPLETE current content.
+     b. Construct the new file content by applying your changes to the complete content you just read.
+     c. Call write_file with the full new content. Never pass a partial file.
 5. Commit with commit_changes (use a clear, descriptive message).
 6. After implementation, return a concise summary of what was changed.
 

--- a/src/tokuye/tools/strands_tools/file_management.py
+++ b/src/tokuye/tools/strands_tools/file_management.py
@@ -294,7 +294,7 @@ def read_lines(file_path: str, start_line: int, end_line: int) -> str:
 
 @tool(
     name="write_file",
-    description="Write UTF-8 text to a file. Access is restricted to the directory tree under `root_dir`; files matched by `.gitignore` are denied. Use append=true to append; otherwise it overwrites.",
+    description="Write UTF-8 text to a file. Access is restricted to the directory tree under `root_dir`; files matched by `.gitignore` are denied. Use append=true to append; otherwise it OVERWRITES THE ENTIRE FILE — all existing content is lost. You MUST read the complete file with read_lines first, then pass the full updated content.",
 )
 def write_file(file_path: str, text: str, append: bool = False) -> str:
     """


### PR DESCRIPTION
`apply_patch` から `write_file` へのフォールバック時に、ファイル内容が意図せず上書き・消失するのを防ぐための変更を行いました。`write_file` のツール説明文とDeveloperエージェントのシステムプロンプトの両方を更新し、ファイル全体を上書きするリスクを明示しました。

**実装の詳細**
- `file_management.py`: `write_file` の `@tool` デコレーターの `description` 文字列に、「ファイル全体が上書きされる」「事前に `read_lines` を呼び出す必要がある」旨の警告を追記
- `system_prompt_developer.md`: Workflowセクションの `write_file` フォールバックに関する箇条書きを、順序付きサブステップに置き換え。手順は「①ファイル全体を読む → ②新しい内容を構築する → ③全内容を書き込む」の順序を明示

**注意事項**
- 破壊的変更: なし
- マイグレーション手順: N/A
- 既知の制限事項: N/A
- テスト手順: `apply_patch` が失敗するケースで `write_file` へのフォールバックが発生する場面を再現し、既存ファイルの内容が保持されたまま編集が適用されることを確認する