### PR TITLE
空白・改行のみのメッセージと非同期化の問題を修正

### DIFF
--- a/src/tokuye/agent/node_agents.py
+++ b/src/tokuye/agent/node_agents.py
@@ -252,7 +252,7 @@ class NodeAgents:
         def _handler(**kwargs):
             if "message" in kwargs and kwargs["message"].get("role") == "assistant":
                 for c in kwargs["message"].get("content", []):
-                    if c.get("text"):
+                    if c.get("text", "").strip():
                         self.add_ai_message(c["text"])
 
         return _handler

--- a/src/tokuye/agent/state_machine.py
+++ b/src/tokuye/agent/state_machine.py
@@ -73,7 +73,7 @@ class StateClassifier:
             callback_handler=None,
         )
 
-    def classify(self, current_state: DevState, user_message: str) -> DevState:
+    async def classify(self, current_state: DevState, user_message: str) -> DevState:
         """Return the next state synchronously."""
         if settings.language == "en":
             user_content = (
@@ -88,7 +88,7 @@ class StateClassifier:
         try:
             # Reset history to keep each classification stateless
             self._agent.messages.clear()
-            result = self._agent(user_content)
+            result = await self._agent.invoke_async(user_content)
             raw = str(result)
 
             # Parse JSON
@@ -126,9 +126,9 @@ class StateMachine:
         self._classifier = classifier
         self.state: DevState = DevState.IDLE
 
-    def transition_by_user(self, user_message: str) -> DevState:
+    async def transition_by_user(self, user_message: str) -> DevState:
         """Classify user message and advance state. Returns the new state."""
-        next_state = self._classifier.classify(self.state, user_message)
+        next_state = await self._classifier.classify(self.state, user_message)
         self.state = next_state
         return self.state
 

--- a/src/tokuye/agent/strands_agent.py
+++ b/src/tokuye/agent/strands_agent.py
@@ -212,7 +212,7 @@ class StrandsAgent:
 
         # --- Determine next state ----------------------------------------
         if message is not None:
-            next_state = sm.transition_by_user(message)
+            next_state = await sm.transition_by_user(message)
         else:
             next_state = sm.state
 
@@ -286,7 +286,7 @@ class StrandsAgent:
         if "message" in kwargs and kwargs["message"].get("role") == "assistant":
             if kwargs["message"].get("content") is not None:
                 for c in kwargs["message"]["content"]:
-                    if c.get("text"):
+                    if c.get("text", "").strip():
                         self.add_ai_message(c["text"])
 
     def _update_token_usage(self, result: AgentResult):


### PR DESCRIPTION
PR Creatorノードにおける空白・改行のみのメッセージが表示される問題を修正し、状態遷移処理を非同期化しました。

**変更の詳細**

**`src/tokuye/agent/node_agents.py`**
- `_make_callback` 内の `_handler` 関数で、テキストの存在チェックを `c.get("text")` から `c.get("text", "").strip()` に変更し、空白・改行のみのメッセージを抑制

**`src/tokuye/agent/strands_agent.py`**
- `_callback_handler` メソッドで同様の空白チェックを修正（`c.get("text")` → `c.get("text", "").strip()`）
- `_call_v2` メソッドで状態遷移呼び出しを同期から非同期に変更（`sm.transition_by_user(message)` → `await sm.transition_by_user(message)`）

**`src/tokuye/agent/state_machine.py`**
- `StateClassifier.classify` を `async def` に変更し、エージェント呼び出しを `await self._agent.invoke_async(user_content)` に変更
- `StateMachine.transition_by_user` を `async def` に変更し、内部の `classify` 呼び出しを `await` に変更

**注意事項**
- **破壊的変更**: `StateClassifier.classify` および `StateMachine.transition_by_user` のシグネチャが同期から非同期に変更された。これらのメソッドを直接呼び出している箇所がある場合、`await` を追加する必要がある。
- **必要なマイグレーション手順**: `transition_by_user` または `classify` を呼び出している他のコードが存在する場合、呼び出し元も `async/await` に対応させること。
- **既知の制限事項**: N/A
- **テスト手順**: PR Creatorノードを使用するフローを実行し、空白・改行のみのメッセージが表示されないことを確認する。また、状態遷移時にUIがブロックされないことを確認する。