### PR TITLE
feat(patch_tools): パッチ適用失敗時に失敗hunk周辺のファイル内容をエラーメッセージに付加する

### DIFF
--- a/src/tokuye/tools/strands_tools/patch_tools.py
+++ b/src/tokuye/tools/strands_tools/patch_tools.py
@@ -9,6 +9,36 @@ from tokuye.utils.config import settings
 logger = logging.getLogger(__name__)
 
 
+def _extract_failed_hunks(diff: str) -> list[tuple[str, int]]:
+    """Parse a unified diff string and return (file_path, hunk_start_line) for each hunk."""
+    results = []
+    current_file = None
+    for line in diff.splitlines():
+        file_match = re.match(r"^\+\+\+ b/(.+)$", line)
+        if file_match:
+            current_file = file_match.group(1)
+        hunk_match = re.match(r"^@@ -(\d+)(?:,\d+)? \+\d+(?:,\d+)? @@", line)
+        if hunk_match and current_file is not None:
+            results.append((current_file, int(hunk_match.group(1))))
+    return results
+
+
+def _build_context_hint(file_path: str, line: int, radius: int = 10) -> str:
+    """Return a string showing lines around `line` (1-indexed) in `file_path`.
+    Returns empty string if the file cannot be read."""
+    try:
+        with open(file_path, "r", encoding="utf-8", errors="replace") as f:
+            lines = f.readlines()
+        start = max(0, line - 1 - radius)
+        end = min(len(lines), line - 1 + radius + 1)
+        numbered = []
+        for i, content in enumerate(lines[start:end], start=start + 1):
+            numbered.append(f"  {i}: {content.rstrip()}")
+        return f"Context around line {line} in {file_path}:\n" + "\n".join(numbered)
+    except Exception:
+        return ""
+
+
 @tool(
     name="apply_patch",
     description="Apply a git diff patch to the repository. Accepts a string containing the diff in git format.",
@@ -118,5 +148,14 @@ def _apply_patch_with_fallbacks(diff: str) -> str:
     final_error = f"All patch application strategies failed:\n{all_errors}"
     logger.error(final_error)
 
-    # As a last resort, display detailed error information
+    # Build context hints for failed hunks
+    hints = []
+    for file_path, hunk_line in _extract_failed_hunks(diff_lf):
+        hint = _build_context_hint(file_path, hunk_line)
+        if hint:
+            hints.append(hint)
+
+    if hints:
+        final_error += "\n\nFile context at failed locations:\n" + "\n".join(hints)
+
     raise RuntimeError(final_error)


### PR DESCRIPTION
## 概要

`patch_tools.py` に、パッチ適用が全戦略で失敗した際の診断機能を追加した。
失敗した hunk の周辺ファイル内容をエラーメッセージに自動付加することで、`write_file` へのフォールバックなしにデバッグ情報を提供できるようにする。

## 背景・動機

従来の実装では、全パッチ戦略が失敗した場合に `git apply` のエラーメッセージのみが返されていた。
このメッセージだけでは「パッチが期待する行番号付近に実際に何が書かれているか」が分からず、原因特定に時間がかかっていた。
本変更により、失敗 hunk の位置情報をエラーメッセージに直接埋め込み、デバッグ効率を向上させる。

## 変更内容

### 追加: `_extract_failed_hunks(diff: str) -> list[tuple[str, int]]`（11〜22行目）

unified diff 文字列を解析し、各 hunk のファイルパスと開始行番号を抽出する。

- `+++ b/<filepath>` パターンで対象ファイルを特定
- `@@ -<line>` パターンで hunk の開始行番号を取得
- `(file_path, hunk_start_line)` タプルのリストを返す

### 追加: `_build_context_hint(file_path: str, line: int, radius: int = 10) -> str`（24〜37行目）

指定行（1-indexed）の前後 `radius` 行（デフォルト10行）をファイルから読み取り、行番号付きの文字列として返す。

- ファイル読み取り失敗時は例外をサイレントに処理し、空文字列を返す
- エンコーディングエラーは `errors="replace"` で吸収する

### 変更: `_apply_patch_with_fallbacks` のエラーハンドリング強化（151〜159行目）

全パッチ戦略が失敗した後、以下の処理を追加した。

```python
hints = []
for file_path, hunk_line in _extract_failed_hunks(diff_lf):
    hint = _build_context_hint(file_path, hunk_line)
    if hint:
        hints.append(hint)

if hints:
    final_error += "\n\nFile context at failed locations:\n" + "\n".join(hints)
```

ヒントが1件以上生成された場合のみ、最終エラーメッセージにコンテキストセクションを追記する。
ヒントが0件の場合（ファイルが存在しない・読み取り不可など）は従来と同じエラーメッセージが返る。

## 破壊的変更

なし。既存の全機能・インターフェースは保持されている。

## テスト手順

1. パッチ適用が全戦略で失敗するケースを用意する（例: 行番号がずれた diff を渡す）
2. `apply_patch` を呼び出す
3. 返却されるエラーメッセージに `File context at failed locations:` セクションが含まれ、失敗 hunk 周辺のファイル内容が行番号付きで表示されることを確認する

## 既知の制限事項

- `_build_context_hint` はファイル読み取り失敗時に空文字列を返すため、対象ファイルが存在しない・読み取り不可の場合はコンテキストが表示されない（エラーは握り潰される）
- `_extract_failed_hunks` は diff 内の全 hunk を対象とするため、複数ファイル・複数 hunk のパッチでは出力が長くなる可能性がある
