### PR TITLE
fix: developer_tools から write_file を削除し、ファイル編集を apply_patch に一本化

### DIFF
--- a/src/tokuye/prompts/system_prompt_developer.md
+++ b/src/tokuye/prompts/system_prompt_developer.md
@@ -16,9 +16,7 @@ Project root: {project_root}
    - Otherwise → call `create_branch` to create a new work branch.
 3. **Implement changes** — follow the plan exactly, file by file.
    - Default tool: `apply_patch`
-   - Fallback (only when `apply_patch` fails): `write_file`
-     - Before calling `write_file`, call `read_lines` on the full file first.
-     - Pass the complete new file content. Never pass a partial file.
+   - If `apply_patch` fails all retries, stop and report the error. Do not attempt to work around it.
 4. **Commit** — call `commit_changes` with a clear, descriptive message.
 5. **Report** — return a concise summary: what changed, which files, which lines.
 
@@ -28,9 +26,8 @@ Project root: {project_root}
 
 | Priority | Tool | When to use |
 |----------|------|-------------|
-| 1st | `apply_patch` | All file edits (default) |
-| 2nd | `write_file` | Only when `apply_patch` fails cleanly |
-| Any | `read_lines` | Before `write_file`, or to verify content |
+| 1st | `apply_patch` | All file edits (only option) |
+| Any | `read_lines` | To verify content before/after patching |
 | Any | `file_search`, `list_directory` | Navigation only |
 | Any | `copy_file`, `move_file`, `file_delete` | Structural changes per plan |
 | Required | `create_branch` | Once, at the start (unless branch already exists) |
@@ -42,6 +39,7 @@ Project root: {project_root}
 
 1. **Implement exactly what the plan says.** No extra changes, no refactors, no style fixes.
 2. **Minimal diff.** Touch only the files and lines the plan specifies.
-3. **If `apply_patch` fails**, read the full file with `read_lines`, apply your change mentally, then call `write_file` with the complete content.
-4. **If the plan is ambiguous or contradictory**, stop and ask. Do not guess.
-5. **One commit per task.** Commit everything at the end, not incrementally.
+3. **If `apply_patch` fails all retries**, stop immediately and report the failure. Do not attempt alternative file-writing methods.
+4. **One commit per task.** Commit everything at the end, not incrementally.
+
+---

--- a/src/tokuye/tools/strands_tools/__init__.py
+++ b/src/tokuye/tools/strands_tools/__init__.py
@@ -78,7 +78,6 @@ planner_tools = [
 
 developer_tools = [
     read_lines,
-    write_file,
     apply_patch,
     create_branch,
     commit_changes,


### PR DESCRIPTION
## 概要

`developer_tools` から `write_file` を削除し、ファイル編集の手段を `apply_patch` のみに限定する。
合わせてシステムプロンプトを更新し、`write_file` へのフォールバックを排除することで、編集方法を統一・強制する。

---

## 変更内容

### `src/tokuye/tools/strands_tools/__init__.py`

- `developer_tools` リストから `write_file` を削除
- ファイル編集ツールは `apply_patch` のみが残存

> **注意**: `all_tools` リストには `write_file` が引き続き含まれている。これは今回の変更スコープ外（`developer_tools` の限定変更）であり、意図的な差分。

### `src/tokuye/prompts/system_prompt_developer.md`

- **Execution Steps セクション**: `write_file` へのフォールバック手順を削除。`apply_patch` が唯一の選択肢であることを明記
- **Tool Priority テーブル**: `write_file` の記載を削除。ファイル編集は `apply_patch` のみと更新
- **Rules セクション**: `apply_patch` が失敗した場合は代替手段を試みず即座に停止するよう明記

---

## 変更の背景・理由

`write_file` と `apply_patch` の2つのファイル編集手段が並存していたことで、エージェントが状況に応じて `write_file` にフォールバックするケースが発生していた。
`apply_patch` はdiff形式で変更箇所を明示するため、意図しないファイル全体の上書きを防ぎ、変更の追跡・レビューが容易になる。編集手段を `apply_patch` に一本化することで、この問題を根本から排除する。

---

## ⚠️ 破壊的変更

`write_file` が `developer_tools` から削除されたため、**`developer_tools` 経由で `write_file` に依存していたワークフローや呼び出しは動作しなくなる**。

### マイグレーション手順

`write_file` を直接呼び出しているコードや設定がある場合は `apply_patch` に置き換えること。

```diff
- write_file(path="path/to/file", content="...")
+ apply_patch("""
+ *** Begin Patch
+ *** Update File: path/to/file
+ ...diff形式の変更内容...
+ *** End Patch
+ """)
```

### 既知の制限事項

`apply_patch` が失敗した場合、フォールバック手段がなくなったため処理が停止する。
エラーハンドリングが必要なユースケースでは、呼び出し側での考慮が必要。

---

## テスト手順

1. ファイル編集を伴う操作を実行し、`apply_patch` のみで正常に完了することを確認
2. `developer_tools` 経由で `write_file` が利用不可であることを確認
3. `apply_patch` が失敗するケースで、フォールバックなしに処理が停止することを確認
