### PR TITLE
docs(developer): パッチフォーマットルールにコンテキスト行と開始行番号のガイダンスを追加

### DIFF
--- a/src/tokuye/prompts/system_prompt_developer.md
+++ b/src/tokuye/prompts/system_prompt_developer.md
@@ -85,6 +85,27 @@ Example — adding 3 lines inside a 2-line context window:
 - old side: 2 context lines → `b = 2`
 - new side: 2 context lines + 3 added lines → `d = 5`
 
+### Context lines (anchor for `git apply`)
+
+`git apply` locates the hunk by matching context lines against the actual file.
+Too few context lines → the match is ambiguous or fails entirely.
+
+**Rules:**
+- Include **at least 3 context lines** before and after the changed block.
+- If fewer than 3 lines exist at the top or bottom of the file, include all available lines.
+- Context lines must be **copied verbatim** from the file — do not paraphrase or trim.
+
+### Hunk start line (`-<old_start>`)
+
+The `@@ -<old_start>, ...` value must be the **exact 1-indexed line number** of the first context (or removal) line in the hunk.
+
+**How to get it right:**
+1. Call `read_lines` on the target file to see the actual line numbers.
+2. Identify the first line you will include in the hunk (first context line before the change).
+3. Use that line number as `<old_start>`.
+
+Do **not** guess or estimate the start line. Always verify with `read_lines` first.
+
 ### `index` lines
 
 Do **not** include `index <hash>..<hash>` lines in the patch.


### PR DESCRIPTION
## 概要

`system_prompt_developer.md` の `Patch Format Rules (CRITICAL)` セクションに、`git apply` の失敗を防ぐための2つのサブセクションを追加した。

---

## 変更内容

### 追加したセクション

#### `### Context lines (anchor for git apply)`

`git apply` がハンクの位置を特定するためにコンテキスト行を使うという事実を明文化し、以下のルールを規定した。

- 変更ブロックの前後に **最低3行** のコンテキスト行を含めること
- ファイル先頭・末尾で3行未満の場合は存在する全行を含めること
- コンテキスト行はファイルから **逐語的にコピー** すること（要約・省略禁止）

#### `### Hunk start line (-<old_start>)`

ハンクヘッダーの `@@ -<old_start>, ...` に正しい行番号を設定するためのガイダンスを規定した。

- `<old_start>` はハンク内の最初の行（最初のコンテキスト行または削除行）の **1-indexed の正確な行番号** であること
- 推測・目算禁止。必ず `read_lines` で実際の行番号を確認してから設定すること

### 挿入位置

`### Hunk header counts` と `### No trailing metadata` の間に挿入。既存コンテンツへの変更はなし。

---

## 変更の背景

Developerエージェントが生成するパッチで、以下の2種類の `git apply` 失敗が繰り返し発生していた。

1. **コンテキスト行不足** — ハンクの前後にコンテキスト行がなく、`git apply` がハンクの位置を特定できない
2. **開始行番号の誤り** — `@@ -<old_start>` が実際のファイル行番号とずれており、適用位置がずれるか失敗する

既存の `### Hunk header counts` セクションはカウントの誤りをカバーしていたが、これら2点は明示的なルールがなかった。本PRはそのギャップを埋める。

---

## 影響範囲

- 変更対象: `src/tokuye/prompts/system_prompt_developer.md` のみ
- 破壊的変更: なし
- マイグレーション: 不要

---

## テスト観点

Developerエージェントがパッチを生成するシナリオで、以下が改善されることを確認する。

- コンテキスト行不足による `git apply` 失敗の減少
- `@@ -<old_start>` の誤りによる適用位置ずれ・失敗の減少