### PR TITLE
feat: text_edit_tools のエラーパスに logger.error を追加

### DIFF
--- a/src/tokuye/tools/strands_tools/text_edit_tools.py
+++ b/src/tokuye/tools/strands_tools/text_edit_tools.py
@@ -21,6 +21,7 @@ Failure messages are intentionally specific to aid retry:
 """
 
 from pathlib import Path
+import logging
 
 from strands import tool
 from tokuye.tools.strands_tools.utils import (
@@ -29,6 +30,8 @@ from tokuye.tools.strands_tools.utils import (
     get_validated_relative_path,
 )
 from tokuye.utils.config import settings
+
+logger = logging.getLogger(__name__)
 
 
 # ---------------------------------------------------------------------------
@@ -124,20 +127,25 @@ def replace_exact(file_path: str, old_text: str, new_text: str) -> str:
     try:
         abs_path, content = _read_validated_file(file_path)
     except FileValidationError as e:
+        logger.error("text_edit: file validation error in %s: %s", file_path, e)
         return f"Error: {e}"
     except (FileNotFoundError, IsADirectoryError) as e:
+        logger.error("text_edit: file not found or is directory in %s: %s", file_path, e)
         return f"Error: {e}"
     except Exception as e:
+        logger.error("text_edit: unexpected error reading %s: %s", file_path, e)
         return f"Error reading file: {e}"
 
     idx, err = _locate_exact(content, old_text, "old_text")
     if err:
+        logger.error("text_edit: locate error in %s: %s", file_path, err)
         return err
 
     new_content = content[:idx] + new_text + content[idx + len(old_text):]
     try:
         abs_path.write_text(new_content, encoding="utf-8")
     except Exception as e:
+        logger.error("text_edit: error writing %s: %s", file_path, e)
         return f"Error writing file: {e}"
 
     return (
@@ -174,14 +182,18 @@ def insert_after_exact(file_path: str, anchor_text: str, new_text: str) -> str:
     try:
         abs_path, content = _read_validated_file(file_path)
     except FileValidationError as e:
+        logger.error("text_edit: file validation error in %s: %s", file_path, e)
         return f"Error: {e}"
     except (FileNotFoundError, IsADirectoryError) as e:
+        logger.error("text_edit: file not found or is directory in %s: %s", file_path, e)
         return f"Error: {e}"
     except Exception as e:
+        logger.error("text_edit: unexpected error reading %s: %s", file_path, e)
         return f"Error reading file: {e}"
 
     idx, err = _locate_exact(content, anchor_text, "anchor_text")
     if err:
+        logger.error("text_edit: locate error in %s: %s", file_path, err)
         return err
 
     insert_pos = idx + len(anchor_text)
@@ -189,6 +201,7 @@ def insert_after_exact(file_path: str, anchor_text: str, new_text: str) -> str:
     try:
         abs_path.write_text(new_content, encoding="utf-8")
     except Exception as e:
+        logger.error("text_edit: error writing %s: %s", file_path, e)
         return f"Error writing file: {e}"
 
     return (
@@ -225,20 +238,25 @@ def insert_before_exact(file_path: str, anchor_text: str, new_text: str) -> str:
     try:
         abs_path, content = _read_validated_file(file_path)
     except FileValidationError as e:
+        logger.error("text_edit: file validation error in %s: %s", file_path, e)
         return f"Error: {e}"
     except (FileNotFoundError, IsADirectoryError) as e:
+        logger.error("text_edit: file not found or is directory in %s: %s", file_path, e)
         return f"Error: {e}"
     except Exception as e:
+        logger.error("text_edit: unexpected error reading %s: %s", file_path, e)
         return f"Error reading file: {e}"
 
     idx, err = _locate_exact(content, anchor_text, "anchor_text")
     if err:
+        logger.error("text_edit: locate error in %s: %s", file_path, err)
         return err
 
     new_content = content[:idx] + new_text + content[idx:]
     try:
         abs_path.write_text(new_content, encoding="utf-8")
     except Exception as e:
+        logger.error("text_edit: error writing %s: %s", file_path, e)
         return f"Error writing file: {e}"
 
     return (


### PR DESCRIPTION
## 概要

`text_edit_tools.py` の3関数（`replace_exact` / `insert_after_exact` / `insert_before_exact`）のエラーパスに `logger.error` を追加した。
これまでエラー発生時はツールの戻り値（文字列）にしか情報が残らず、ログ基盤での観測が不可能だった。

---

## 変更内容

### 追加したインポート・設定

```python
import logging
logger = logging.getLogger(__name__)
```

モジュールレベルで標準的なロガーを設定。既存の依存関係への影響はない。

### 各関数のエラーパス

3関数それぞれに対して、以下の3箇所に `logger.error` を追加した。

| エラーパス | ログメッセージ例 |
|---|---|
| ファイル読み込み失敗（`FileValidationError`） | `text_edit: file validation error in {file_path}: {e}` |
| ファイル読み込み失敗（`FileNotFoundError` / `IsADirectoryError`） | `text_edit: file not found or is directory in {file_path}: {e}` |
| ファイル読み込み失敗（予期しない例外） | `text_edit: unexpected error reading {file_path}: {e}` |
| `_locate_exact` がエラーを返した場合 | `text_edit: locate error in {file_path}: {err}` |
| ファイル書き込み失敗 | `text_edit: error writing {file_path}: {e}` |

ログメッセージのプレフィックスは `text_edit:` で統一し、ログ検索・フィルタリングを容易にした。

---

## 変更しなかったもの

- 関数のシグネチャ・戻り値の形式は一切変更していない
- 正常系のロジックには手を加えていない
- `_locate_exact` / `_validate_path` / `_read_validated_file` 等のヘルパー関数は変更していない

---

## テスト手順

各関数のエラーパスを意図的に発生させ、`logger.error` が呼び出されることを確認する。

1. **ファイル読み込みエラー**：存在しないパスや gitignore 対象のパスを渡す
2. **テキスト未検出**：`old_text` / `anchor_text` にファイル内に存在しない文字列を渡す
3. **ファイル書き込みエラー**：対象ファイルを読み取り専用にした状態で実行する

---

## 破壊的変更

なし

## マイグレーション手順

なし
