### PR TITLE
feat: ステートマシンに AWAITING_PR_FEEDBACK / AWAITING_REVIEW_FEEDBACK を追加

### DIFF
--- a/src/tokuye/agent/state_machine.py
+++ b/src/tokuye/agent/state_machine.py
@@ -32,6 +32,8 @@ class DevState(Enum):
     SELF_REVIEWING = "SELF_REVIEWING"
     REVIEWING = "REVIEWING"
     AWAITING_REVIEW_APPROVAL = "AWAITING_REVIEW_APPROVAL"
+    AWAITING_PR_FEEDBACK = "AWAITING_PR_FEEDBACK"
+    AWAITING_REVIEW_FEEDBACK = "AWAITING_REVIEW_FEEDBACK"
 
     @classmethod
     def from_str(cls, value: str) -> "DevState":
@@ -48,7 +50,7 @@ class DevState(Enum):
 _AUTO_ADVANCE: dict["DevState", "DevState"] = {
     DevState.PLANNING: DevState.AWAITING_APPROVAL,
     DevState.IMPLEMENTING: DevState.AWAITING_REVIEW,
-    DevState.PR_CREATING: DevState.IDLE,
+    DevState.PR_CREATING: DevState.AWAITING_PR_FEEDBACK,
     DevState.SELF_REVIEWING: DevState.AWAITING_REVIEW,
     DevState.REVIEWING: DevState.AWAITING_REVIEW_APPROVAL,
 }

--- a/src/tokuye/agent/strands_agent.py
+++ b/src/tokuye/agent/strands_agent.py
@@ -305,7 +305,7 @@ class StrandsAgent:
                 sm.transition_after_node()
                 self.add_system_message(f"[State: {sm.state.value}]")
 
-        elif next_state == DevState.AWAITING_REVIEW:
+        elif next_state in (DevState.AWAITING_REVIEW, DevState.AWAITING_PR_FEEDBACK, DevState.AWAITING_REVIEW_FEEDBACK):
             result = None
 
         else:

--- a/src/tokuye/prompts/state_classifier_prompt.md
+++ b/src/tokuye/prompts/state_classifier_prompt.md
@@ -14,6 +14,8 @@
 - `SELF_REVIEWING`: PR Creatorが自己レビュー中
 - `REVIEWING`: Reviewerが他者のPRをレビュー中
 - `AWAITING_REVIEW_APPROVAL`: Reviewerがレビュー内容を提示し、投稿前の承認を待っている
+- `AWAITING_PR_FEEDBACK`: 自分が出したPRにレビューコメントが来るのを待っている
+- `AWAITING_REVIEW_FEEDBACK`: 自分が投稿したレビューに対する返答を待っている
 
 ## 遷移ルール
 
@@ -23,6 +25,8 @@
 - 他者のPRレビュー依頼 → `REVIEWING`
 - 自己レビュー依頼（自分のコード・ブランチ・PR） → `SELF_REVIEWING`
 - PR作成依頼 → `PR_CREATING`
+- 自分のPRへのコメント確認・修正依頼 → `PLANNING`
+- 他者のPRへのコメント返答確認・追加レビュー依頼 → `REVIEWING`
 
 ### PLANNING からの遷移
 - 調査・質問が完結した（「ありがとう」「わかった」等） → `IDLE`
@@ -53,8 +57,18 @@
 - レビュー内容の提示完了 → `AWAITING_REVIEW_APPROVAL`（自動遷移）
 
 ### AWAITING_REVIEW_APPROVAL からの遷移
-- 承認・投稿指示（「投稿して」「ok」等） → `IDLE`
+- 承認・投稿指示（「投稿して」「ok」等） → `AWAITING_REVIEW_FEEDBACK`
 - 修正依頼 → `REVIEWING`
+
+### AWAITING_PR_FEEDBACK からの遷移
+- コメント確認・修正依頼（「コメント来た」「確認して」「修正して」等） → `PLANNING`
+- 完結・終了（「マージした」「ありがとう」等） → `IDLE`
+- 上記以外 → `PLANNING`
+
+### AWAITING_REVIEW_FEEDBACK からの遷移
+- コメントへの返答確認・追加レビュー依頼（「コメント来た」「確認して」「反論きた」等） → `REVIEWING`
+- 完結・終了（「ありがとう」「終わり」等） → `IDLE`
+- 上記以外 → `REVIEWING`
 
 ## 出力形式
 

--- a/src/tokuye/prompts/state_classifier_prompt_en.md
+++ b/src/tokuye/prompts/state_classifier_prompt_en.md
@@ -14,6 +14,8 @@ You receive the current state and the user's message, and return the next state.
 - `SELF_REVIEWING`: PR Creator is performing a self-review.
 - `REVIEWING`: Reviewer is reviewing someone else's PR.
 - `AWAITING_REVIEW_APPROVAL`: Reviewer has presented review content and is waiting for approval before posting.
+- `AWAITING_PR_FEEDBACK`: Waiting for review comments on a PR you submitted
+- `AWAITING_REVIEW_FEEDBACK`: Waiting for a response to a review you posted
 
 ## Transition rules
 
@@ -23,6 +25,8 @@ You receive the current state and the user's message, and return the next state.
 - Request to review someone else's PR → `REVIEWING`
 - Self-review request (own code / branch / PR) → `SELF_REVIEWING`
 - PR creation request → `PR_CREATING`
+- Comment check / fix request on your own PR → `PLANNING`
+- Response check / additional review request on someone else's PR → `REVIEWING`
 
 ### From PLANNING
 - Investigation / question is resolved ("thanks", "got it", etc.) → `IDLE`
@@ -53,8 +57,18 @@ You receive the current state and the user's message, and return the next state.
 - Review content presented (auto-advance) → `AWAITING_REVIEW_APPROVAL`
 
 ### From AWAITING_REVIEW_APPROVAL
-- Approval / post instruction ("post it", "ok", etc.) → `IDLE`
+- Approval / post instruction ("post it", "ok", etc.) → `AWAITING_REVIEW_FEEDBACK`
 - Revision request → `REVIEWING`
+
+### From AWAITING_PR_FEEDBACK
+- Comment received / fix requested ("comment came in", "please check", "please fix", etc.) → `PLANNING`
+- Completion / closure ("merged", "thanks", etc.) → `IDLE`
+- Anything else → `PLANNING`
+
+### From AWAITING_REVIEW_FEEDBACK
+- Response to comment / additional review requested ("comment came in", "please check", "got a rebuttal", etc.) → `REVIEWING`
+- Completion / closure ("thanks", "done", etc.) → `IDLE`
+- Anything else → `REVIEWING`
 
 ## Output format
 


### PR DESCRIPTION
## 概要

ステートマシンに `AWAITING_PR_FEEDBACK` と `AWAITING_REVIEW_FEEDBACK` の2つの新しい状態を追加した。
これにより、PRへのレビューコメント待ちと、自分が投稿したレビューへの返答待ちを、既存の `AWAITING_REVIEW` とは独立して管理できるようになる。

---

## 背景・動機

従来は PR 作成後も `AWAITING_REVIEW` に遷移していたため、「実装レビュー待ち」と「PRへのフィードバック待ち」が同じ状態に混在していた。
また、レビュー投稿後の状態も明示的に表現できていなかった。
今回の変更でそれぞれを独立した状態として分離し、ワークフローの意図をより正確にモデル化する。

---

## 変更内容

### `state_machine.py`
- `DevState` enum に `AWAITING_PR_FEEDBACK`・`AWAITING_REVIEW_FEEDBACK` を追加
- `_AUTO_ADVANCE` に `PR_CREATING → AWAITING_PR_FEEDBACK` の遷移を追加
  - **破壊的変更**: 従来 `PR_CREATING` 完了後は `IDLE` に自動遷移していたが、今後は `AWAITING_PR_FEEDBACK` に遷移する

### `strands_agent.py`
- `_call_v2` のディスパッチ処理で `AWAITING_PR_FEEDBACK` と `AWAITING_REVIEW_FEEDBACK` を明示的にハンドリング
  - 両状態とも `AWAITING_REVIEW` と同様に `result = None`（ノード呼び出しなし）として処理
  - これにより `else` ブロック（planner fallback）に落ちることなく、待機状態として正しく扱われる

### `state_classifier_prompt.md`（日本語）
- 新状態の定義を「ステート定義」セクションに追記
- `AWAITING_REVIEW_APPROVAL` からの遷移先として `AWAITING_REVIEW_FEEDBACK` を追加
- `AWAITING_PR_FEEDBACK` の遷移ルールを追加（コメント確認・修正依頼 → `PLANNING`、完結 → `IDLE`）
- `AWAITING_REVIEW_FEEDBACK` の遷移ルールを追加（返答確認・追加レビュー → `REVIEWING`、完結 → `IDLE`）
- `IDLE` からの遷移ルールに、PRフィードバック・レビューフィードバック起点のケースを追加

### `state_classifier_prompt_en.md`（英語）
- 日本語プロンプトと同等の変更を英語で適用

---

## 破壊的変更

| 変更箇所 | 変更前 | 変更後 |
|---|---|---|
| `_AUTO_ADVANCE[PR_CREATING]` | `IDLE` | `AWAITING_PR_FEEDBACK` |

`PR_CREATING` 完了後の自動遷移先が変わるため、**このステート遷移に依存しているコードやテストは動作が変わる可能性がある**。
既存のテストケースで `PR_CREATING → IDLE` を期待しているものがあれば `PR_CREATING → AWAITING_PR_FEEDBACK` に修正が必要。

---

## テスト手順

1. PR作成フローを実行し、`PR_CREATING` 完了後に `AWAITING_PR_FEEDBACK` へ遷移することを確認
2. `AWAITING_PR_FEEDBACK` 状態で「コメント来た」「修正して」等を入力し、`PLANNING` へ遷移することを確認
3. `AWAITING_PR_FEEDBACK` 状態で「マージした」「ありがとう」等を入力し、`IDLE` へ遷移することを確認
4. `AWAITING_REVIEW_APPROVAL` で承認後、`AWAITING_REVIEW_FEEDBACK` へ遷移することを確認
5. `AWAITING_REVIEW_FEEDBACK` 状態で「反論きた」「確認して」等を入力し、`REVIEWING` へ遷移することを確認
6. `AWAITING_REVIEW_FEEDBACK` 状態で「ありがとう」「終わり」等を入力し、`IDLE` へ遷移することを確認
7. 各新状態でディスパッチが `result = None`（ノード呼び出しなし）として処理されることを確認（planner fallback に落ちないこと）
