### PR TITLE
feat: PLANNINGで受け取ったissueコンテキストをPR Creatorに渡す

### DIFF
--- a/src/tokuye/agent/node_agents.py
+++ b/src/tokuye/agent/node_agents.py
@@ -284,13 +284,20 @@ class NodeAgents:
         self._update_token_usage(result, model_identifier=impl_identifier)
         return result
 
-    async def invoke_pr_creator(self, message: str):
+    async def invoke_pr_creator(self, message: str, issue_context: str = ""):
         """Translate Developer output first, then invoke PR Creator."""
         translated = self.translate_developer_output_for_pr_creator(message)
         self.add_system_message("[Developer output structured for PR Creator]")
         token_tracker.reset_turn()
         pr_identifier = settings.pr_model_identifier or settings.model_identifier
-        result = await self.pr_creator.invoke_async(translated)
+        if issue_context:
+            user_prompt = (
+                f"## Original Issue / Task Context\n{issue_context}\n\n"
+                f"## Implementation Summary\n{translated}"
+            )
+        else:
+            user_prompt = translated
+        result = await self.pr_creator.invoke_async(user_prompt)
         self._update_token_usage(result, model_identifier=pr_identifier)
         return result
 

--- a/src/tokuye/agent/strands_agent.py
+++ b/src/tokuye/agent/strands_agent.py
@@ -192,6 +192,7 @@ class StrandsAgent:
         self._last_planner_output: str = ""
         self._last_developer_output: str = ""
         self.current_task_branch: str = ""  # ← add this line
+        self._last_issue_context: str = ""  # user instruction at PLANNING time, passed to PR Creator
 
     async def __call__(self, *args, **kwargs):
         self.set_thinking(True)
@@ -247,6 +248,7 @@ class StrandsAgent:
             result = await nodes.invoke_planner(planner_input)
             # Capture Planner output for downstream nodes
             self._last_planner_output = str(result)
+            self._last_issue_context = message
             sm.transition_after_node()  # PLANNING → AWAITING_APPROVAL
             self.add_system_message(f"[State: {sm.state.value}]")
 
@@ -289,9 +291,13 @@ class StrandsAgent:
                 if next_state == DevState.PR_CREATING and self._last_developer_output
                 else message
             )
-            result = await nodes.invoke_pr_creator(source)
+            result = await nodes.invoke_pr_creator(
+                source,
+                issue_context=self._last_issue_context if next_state == DevState.PR_CREATING else "",
+            )
             if next_state == DevState.PR_CREATING:
                 self._last_developer_output = ""  # consumed
+                self._last_issue_context = ""    # consumed
                 sm.transition_after_node()
                 self.add_system_message(f"[State: {sm.state.value}]")
             elif next_state == DevState.SELF_REVIEWING:


### PR DESCRIPTION
## 概要

PLANNINGステージでユーザーから受け取ったオリジナルのissueコンテキストを、PR_CREATINGステージまで保持してPR Creatorに渡せるようにした。

これまでPR Creatorが受け取れる情報は「Developerの実装サマリー（翻訳・整形済み）」のみだった。本PRにより、元のissue内容も合わせて渡されるようになり、PR Creatorがより文脈に即したプルリクエストを作成できるようになる。

---

## 変更ファイル

- `src/tokuye/agent/strands_agent.py`
- `src/tokuye/agent/node_agents.py`

---

## 変更詳細

### `strands_agent.py`

**インスタンス変数の追加**

```python
self._last_issue_context: str = ""
```

`_last_planner_output` / `_last_developer_output` と同様のバッファとして追加。

**PLANNINGステートでの保存**

```python
self._last_issue_context = message  # ユーザー入力をそのまま保持
```

PLANNINGステートに入ったとき、ユーザーが送ったメッセージ（issueの内容）を保存する。

**PR_CREATINGステートでの受け渡しとクリア**

```python
result = await nodes.invoke_pr_creator(
    source,
    issue_context=self._last_issue_context if next_state == DevState.PR_CREATING else "",
)
# ...
self._last_issue_context = ""  # consumed
```

PR_CREATINGのときのみ `issue_context` を渡す。SELF_REVIEWINGでは渡さない（ユーザーが直接指示するケースのため）。処理後はクリアして次サイクルへの持ち越しを防ぐ。

---

### `node_agents.py`

**`invoke_pr_creator` にオプション引数を追加**

```python
async def invoke_pr_creator(self, message: str, issue_context: str = ""):
```

デフォルト値を空文字列にすることで、既存の呼び出し箇所は無変更で動作する。

**PR Creatorへのプロンプト構造化**

```python
if issue_context:
    user_prompt = (
        f"## Original Issue / Task Context\n{issue_context}\n\n"
        f"## Implementation Summary\n{translated}"
    )
else:
    user_prompt = translated
```

`issue_context` が存在する場合、元のissue内容と実装サマリーを明示的なセクション見出しで結合してPR Creatorに渡す。存在しない場合は従来通り翻訳済みサマリーのみを渡す。

---

## 影響範囲

| 項目 | 内容 |
|------|------|
| 破壊的変更 | **なし**。`invoke_pr_creator` の新引数はオプション（デフォルト `""`）のため、既存の呼び出し箇所は変更不要 |
| 影響するコードパス | `state_machine_mode` が有効な場合の `PR_CREATING` ステートのみ |
| 影響しないコードパス | `SELF_REVIEWING` ステート、v1フロー（`_call_v1`）、`invoke_pr_creator` の既存呼び出し箇所 |
| 状態管理 | `_last_issue_context` はPR_CREATING処理後にクリアされるため、次サイクルへの意図しない持ち越しは発生しない |

---

## テスト手順

1. `state_machine_mode` を有効にした状態で、PLANNING → 実装承認 → IMPLEMENTING → PR_CREATING の一連フローを実行する
2. 生成されたPRの説明に、PLANNINGで入力したオリジナルのissue内容が反映されていることを確認する
3. `invoke_pr_creator` を `issue_context` なしで呼び出す既存パス（SELF_REVIEWINGなど）が正常動作することを確認する
