### PR TITLE
fix: コードブロック内ラベルの意図しない中央寄せを修正

### DIFF
--- a/src/tokuye/textual/chat_interface.css
+++ b/src/tokuye/textual/chat_interface.css
@@ -130,14 +130,14 @@ ChatMessageWidget Markdown {
 
 Label {
     width: 100%;
-    text-align: center;
-    padding: 1 0;
 }
 
 #thinking-label {
     height: auto;
     margin-bottom: 1;
     text-style: bold;
+    text-align: center;
+    padding: 1 0;
 }
 
 .hidden {


### PR DESCRIPTION
## 概要

`ChatMessageWidget` 内の `MarkdownFence`（コードブロック）のラベルが中央寄せになってしまっていた問題を修正する。

## 背景・原因

`chat_interface.css` のグローバル `Label` ルールに `text-align: center` と `padding: 1 0` が定義されていた。このルールが `MarkdownFence` 内部のラベルにも適用されてしまい、コードブロックのテキストが中央寄せになって読みづらい状態になっていた。

## 変更内容

**`src/tokuye/textual/chat_interface.css`**

| ルール | 変更前 | 変更後 |
|---|---|---|
| `Label`（グローバル） | `width: 100%` + `text-align: center` + `padding: 1 0` | `width: 100%` のみ |
| `#thinking-label` | `height: auto` + `margin-bottom: 1` + `text-style: bold` | 上記に加え `text-align: center` + `padding: 1 0` を追加 |

`text-align: center` と `padding: 1 0` を `Label` グローバルルールから削除し、実際に中央寄せが必要な `#thinking-label` のみに限定して適用するよう変更した。

## 影響範囲

- `#thinking-label`（"thinking..." 表示）: 従来どおり中央寄せ・上下パディングあり
- `MarkdownFence` 内のラベル: 左寄せに戻り、コードブロックが正常に表示される
- その他の `Label` ウィジェット: グローバルルールの `text-align: center` が外れるため、デフォルト（左寄せ）になる

## テスト手順

1. チャット画面を起動する
2. コードブロックを含むメッセージを表示し、コードが**左寄せ**になっていることを確認する
3. エージェントが処理中に表示される "thinking..." ラベルが**中央寄せ**になっていることを確認する

## 破壊的変更

なし
