### PR TITLE
docs: add binary install via install.sh + update theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,11 @@ Full documentation including configuration, features, and advanced usage is avai
 ## Quick Start
 
 ```bash
-cd /path/to/your/project
-mkdir -p .tokuye
+# 1. Install (macOS / Linux)
+curl -fsSL https://raw.githubusercontent.com/ken11/tokuye/main/install.sh | sh
 
+# 2. Create config
+mkdir -p .tokuye
 cat > .tokuye/config.yaml << EOF
 bedrock_model_id: global.anthropic.claude-sonnet-4-6
 bedrock_embedding_model_id: amazon.titan-embed-text-v2:0
@@ -27,22 +29,24 @@ strands_session_dir: sessions
 name: Alice
 EOF
 
-uvx --from git+https://github.com/ken11/tokuye.git tokuye --project-root .
+# 3. Run
+tokuye --project-root .
 ```
 
 ## Prerequisites
 
 - **AWS Bedrock Access**: IAM credentials with Bedrock permissions
-- **Python**: 3.10 or higher
-- **uv**: Fast Python package installer ([installation guide](https://docs.astral.sh/uv/getting-started/installation/))
 
 ## Installation
 
 ```bash
-# Run directly (no install)
+# macOS / Linux — pre-built binary (recommended)
+curl -fsSL https://raw.githubusercontent.com/ken11/tokuye/main/install.sh | sh
+
+# Run directly via uvx (no install, requires uv)
 uvx --from git+https://github.com/ken11/tokuye.git tokuye --project-root /path/to/your/project
 
-# Or install globally
+# Install globally via uv tool (requires uv)
 uv tool install git+https://github.com/ken11/tokuye.git
 tokuye --project-root /path/to/your/project
 ```

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -1,6 +1,36 @@
 # Installation
 
-## Quick Start with uvx (Recommended)
+## Binary Install (macOS / Linux)
+
+The easiest way to install Tokuye. Downloads a pre-built binary — no Python or uv required.
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/ken11/tokuye/main/install.sh | sh
+```
+
+The script auto-detects your OS and architecture (`darwin/linux` × `x86_64/arm64`) and installs the binary to `~/.local/bin/tokuye`.
+
+**Install a specific version:**
+
+```bash
+VERSION=v0.1.0 curl -fsSL https://raw.githubusercontent.com/ken11/tokuye/main/install.sh | sh
+```
+
+**Install to a custom directory:**
+
+```bash
+INSTALL_DIR=/usr/local/bin curl -fsSL https://raw.githubusercontent.com/ken11/tokuye/main/install.sh | sh
+```
+
+!!! note "PATH"
+    If `~/.local/bin` is not in your `PATH`, the script will print a reminder. Add the following to your shell profile (`~/.zshrc`, `~/.bashrc`, etc.):
+    ```bash
+    export PATH="$HOME/.local/bin:$PATH"
+    ```
+
+---
+
+## Quick Start with uvx (No Install)
 
 Run Tokuye directly without installation:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,7 +17,33 @@ Tokuye is an AI-powered development assistant that understands your entire proje
 - **MCP Support**: Extend capabilities via external MCP servers
 - **State Machine Mode**: Structured multi-agent workflow (Planner → Developer → PR Creator → Reviewer)
 
+## Install
+
+=== "macOS / Linux (Recommended)"
+
+    ```bash
+    curl -fsSL https://raw.githubusercontent.com/ken11/tokuye/main/install.sh | sh
+    ```
+
+    This downloads the pre-built binary for your platform and installs it to `~/.local/bin`.
+
+=== "uvx (no install)"
+
+    ```bash
+    uvx --from git+https://github.com/ken11/tokuye.git tokuye --project-root .
+    ```
+
+=== "uv tool"
+
+    ```bash
+    uv tool install git+https://github.com/ken11/tokuye.git
+    ```
+
+→ See [Installation](getting-started/installation.md) for all options and details.
+
 ## Quick Start
+
+After installing, create a config and run:
 
 ```bash
 cd /path/to/your/project
@@ -32,10 +58,10 @@ strands_session_dir: .tokuye/sessions
 name: Alice
 EOF
 
-uvx --from git+https://github.com/ken11/tokuye.git tokuye --project-root .
+tokuye --project-root .
 ```
 
-→ See [Installation](getting-started/installation.md) and [Quick Start](getting-started/quickstart.md) for full details.
+→ See [Quick Start](getting-started/quickstart.md) for full details.
 
 ## Documentation
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,8 +8,8 @@ theme:
   name: material
   palette:
     scheme: slate
-    primary: indigo
-    accent: indigo
+    primary: light blue
+    accent: amber
   features:
     - navigation.tabs
     - navigation.sections


### PR DESCRIPTION
## 概要

`install.sh` を使ったバイナリインストール手順をドキュメントおよびREADMEに追加。あわせてDocsのテーマカラーを更新。

## 変更内容

### README.md
- Quick Start を `install.sh` ワンライナー起点に変更
- Prerequisites から Python / uv 依存を削除（バイナリインストールには不要）
- Installation に `install.sh` を最初の選択肢として追加

### docs/index.md
- **Install** セクションを新設。タブ形式で3方式を並列表示
  - macOS / Linux (Recommended) — `curl | sh`
  - uvx (no install)
  - uv tool
- **Quick Start** をインストール後の設定・実行手順として分離

### docs/getting-started/installation.md
- 先頭に **Binary Install** セクションを追加
  - `VERSION` 環境変数でバージョン固定
  - `INSTALL_DIR` 環境変数でインストール先変更
  - PATH が通っていない場合の対処を admonition で補足

### mkdocs.yml
- テーマカラーを `primary: light blue` / `accent: amber` に変更

## 確認方法

```bash
pip install mkdocs-material
mkdocs serve
```
