### PR TITLE
docs: ドキュメント整備

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,13 @@ Full documentation including configuration, features, and advanced usage is avai
 # 1. Install (macOS / Linux)
 curl -fsSL https://raw.githubusercontent.com/ken11/tokuye/main/install.sh | sh
 
-# 2. Create global config (once, applies to all projects)
+# 2. Set up AWS credentials (choose one)
+export AWS_ACCESS_KEY_ID=your_key
+export AWS_SECRET_ACCESS_KEY=your_secret
+export AWS_DEFAULT_REGION=ap-northeast-1
+# or: export AWS_PROFILE=your_profile
+
+# 3. Create global config (once, applies to all projects)
 mkdir -p "${XDG_CONFIG_HOME:-$HOME/.config}/tokuye"
 cat > "${XDG_CONFIG_HOME:-$HOME/.config}/tokuye/config.yaml" << 'EOF'
 bedrock_model_id: global.anthropic.claude-sonnet-4-6
@@ -28,8 +34,7 @@ pr_branch_prefix: tokuye/
 name: Alice
 EOF
 
-# 3. Run in any project
-cd /path/to/your/project
+# 4. Run in any project
 tokuye --project-root /path/to/your/project
 ```
 

--- a/docs/configuration/global-config.md
+++ b/docs/configuration/global-config.md
@@ -23,6 +23,7 @@ mkdir -p "${XDG_CONFIG_HOME:-$HOME/.config}/tokuye"
 # Create the global config
 cat > "${XDG_CONFIG_HOME:-$HOME/.config}/tokuye/config.yaml" << 'EOF'
 bedrock_model_id: global.anthropic.claude-sonnet-4-6
+bedrock_embedding_model_id: amazon.titan-embed-text-v2:0
 model_temperature: 0.2
 name: Alice
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -48,7 +48,6 @@ bedrock_model_id: global.anthropic.claude-sonnet-4-6
 bedrock_embedding_model_id: amazon.titan-embed-text-v2:0
 model_temperature: 0.2
 pr_branch_prefix: tokuye/
-strands_session_dir: ~/.config/tokuye/sessions
 name: Alice
 EOF
 ```
@@ -76,7 +75,6 @@ bedrock_model_id: global.anthropic.claude-sonnet-4-6
 bedrock_embedding_model_id: amazon.titan-embed-text-v2:0
 model_temperature: 0.2
 pr_branch_prefix: tokuye/
-strands_session_dir: ~/.config/tokuye/sessions
 name: Alice
 EOF
 

--- a/docs/getting-started/prerequisites.md
+++ b/docs/getting-started/prerequisites.md
@@ -1,8 +1,6 @@
 # Prerequisites
 
-## Required
-
-### AWS Bedrock Access
+## AWS Bedrock Access
 
 Tokuye uses AWS Bedrock exclusively for LLM and embedding models. You need:
 
@@ -21,22 +19,20 @@ export AWS_DEFAULT_REGION=ap-northeast-1
 export AWS_PROFILE=your_profile
 ```
 
-### Python
+## Python / uv (Binary install では不要)
 
-Python 3.10 or higher is required.
+If you install Tokuye via the **binary installer** (`install.sh`), Python and uv are **not required**.
 
-### uv
-
-Tokuye uses [uv](https://docs.astral.sh/uv/) as its package manager.
+Python 3.10+ and [uv](https://docs.astral.sh/uv/) are only needed if you use `uvx` or `uv tool install`:
 
 ```bash
-# Install uv
+# Install uv (only if using uvx / uv tool)
 curl -LsSf https://astral.sh/uv/install.sh | sh
 ```
 
-### gh CLI (optional but recommended)
+## gh CLI (optional but recommended)
 
-The [GitHub CLI](https://cli.github.com/) (`gh`) is required for PR creation, review, and issue operations.
+The [GitHub CLI](https://cli.github.com/) (`gh`) enables GitHub-integrated operations such as creating PRs, reviewing PRs, and browsing Issues directly from Tokuye. Without it, these features are unavailable.
 
 ```bash
 # macOS

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -11,7 +11,6 @@ bedrock_model_id: global.anthropic.claude-sonnet-4-6
 bedrock_embedding_model_id: amazon.titan-embed-text-v2:0
 model_temperature: 0.2
 pr_branch_prefix: tokuye/
-strands_session_dir: ~/.config/tokuye/sessions
 name: Alice
 EOF
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -43,22 +43,26 @@ Tokuye is an AI-powered development assistant that understands your entire proje
 
 ## Quick Start
 
-After installing, create a config and run:
+After installing, set up AWS credentials, create a global config, and run:
 
 ```bash
-cd /path/to/your/project
-mkdir -p .tokuye
+# Set up AWS credentials (choose one)
+export AWS_ACCESS_KEY_ID=your_key
+export AWS_SECRET_ACCESS_KEY=your_secret
+export AWS_DEFAULT_REGION=ap-northeast-1
+# or: export AWS_PROFILE=your_profile
 
-cat > .tokuye/config.yaml << EOF
+# Create global config (once — applies to all projects)
+mkdir -p "${XDG_CONFIG_HOME:-$HOME/.config}/tokuye"
+cat > "${XDG_CONFIG_HOME:-$HOME/.config}/tokuye/config.yaml" << 'EOF'
 bedrock_model_id: global.anthropic.claude-sonnet-4-6
 bedrock_embedding_model_id: amazon.titan-embed-text-v2:0
 model_temperature: 0.2
 pr_branch_prefix: tokuye/
-strands_session_dir: .tokuye/sessions
 name: Alice
 EOF
 
-tokuye --project-root .
+tokuye --project-root /path/to/your/project
 ```
 
 → See [Quick Start](getting-started/quickstart.md) for full details.

--- a/src/tokuye/utils/config.py
+++ b/src/tokuye/utils/config.py
@@ -57,7 +57,7 @@ class Settings(BaseSettings):
 
     system_prompt_markdown_path: Optional[str] = ""
 
-    strands_session_dir: str = "sessions"
+    strands_session_dir: str = ".tokuye/sessions"
 
     class Config:
         env_file = ".env"


### PR DESCRIPTION
- README: Quick StartにAWS認証情報の設定手順を追加（Step 2として挿入）
- docs/index.md: Quick StartをglobalConfig作成に変更、strands_session_dir削除、AWS認証手順追加
- docs/getting-started/prerequisites.md: Python/uvをバイナリインストール不要と明記、gh CLIにGitHub連携操作の説明を追加
- docs/getting-started/quickstart.md: config例からstrands_session_dir削除
- docs/getting-started/installation.md: config例(2箇所)からstrands_session_dir削除
- docs/configuration/global-config.md: config例にbedrock_embedding_model_idを追加