### PR TITLE
feat(epic): Epic の docs/ 補助ドキュメントディレクトリ対応

### DIFF
--- a/src/tokuye/prompts/system_prompt_epic_manager.md
+++ b/src/tokuye/prompts/system_prompt_epic_manager.md
@@ -98,6 +98,17 @@ Epic の作業ディレクトリは `<project_root>/epics/<epic_id>/` です。
 - `progress.md` : 進捗ログ（各マイルストーンで `update_epic_progress` で更新）
 - `decisions.md` : 設計判断・申し送り（`save_epic_decisions` で記録）
 - `results/<task_id>.yaml` : タスク結果（ユーザーOK後に `save_task_result` で保存）
+- `docs/<filename>` : 補助ドキュメント（ユーザーの指示があった場合に `write_epic_doc` で作成）
+
+### 補助ドキュメント（docs/）
+
+ユーザーから「仕様書を作って」「API設計をまとめて」「議事録を残して」などの指示があった場合、
+`write_epic_doc` を使って `docs/` ディレクトリに保存してください。
+
+- ファイル名はケバブケースの Markdown ファイルを推奨（例: `api-spec.md`, `meeting-notes.md`）
+- 内容の読み込みは `read_epic_file` で `docs/<filename>` を指定する
+- 一覧確認は `list_epic_docs` を使う
+- 補助ドキュメントの作成はユーザーの明示的な指示がある場合のみ行う（自動生成しない）
 
 ## リポジトリ操作
 

--- a/src/tokuye/prompts/system_prompt_epic_manager_en.md
+++ b/src/tokuye/prompts/system_prompt_epic_manager_en.md
@@ -98,6 +98,17 @@ Save the following files at the appropriate times:
 - `progress.md` : Progress log (update with `update_epic_progress` at each milestone)
 - `decisions.md` : Design decisions / handoff notes (record with `save_epic_decisions`)
 - `results/<task_id>.yaml` : Task results (save with `save_task_result` after user OK)
+- `docs/<filename>` : Supplementary documents (create with `write_epic_doc` when instructed by the user)
+
+### Supplementary Documents (docs/)
+
+When the user asks you to "write a spec", "document the API design", "record meeting notes", etc.,
+use `write_epic_doc` to save the document in the `docs/` directory.
+
+- Prefer kebab-case Markdown filenames (e.g. `api-spec.md`, `meeting-notes.md`)
+- To read a document, use `read_epic_file` with `docs/<filename>` as the filename
+- To list documents, use `list_epic_docs`
+- Only create supplementary documents when explicitly instructed by the user (do not auto-generate)
 
 ## Repository Operations
 

--- a/src/tokuye/tools/strands_tools/epic_tools/__init__.py
+++ b/src/tokuye/tools/strands_tools/epic_tools/__init__.py
@@ -9,6 +9,7 @@ Exports:
 from tokuye.tools.strands_tools.epic_tools.epic_dir_tools import (
     create_epic_dir,
     list_directory_epic,
+    list_epic_docs,
     read_epic_file,
     read_lines_epic,
     save_epic_decisions,
@@ -16,6 +17,7 @@ from tokuye.tools.strands_tools.epic_tools.epic_dir_tools import (
     save_epic_tasks,
     save_task_result,
     update_epic_progress,
+    write_epic_doc,
 )
 from tokuye.tools.strands_tools.epic_tools.repo_ops import (
     manage_code_index_epic,
@@ -42,6 +44,8 @@ epic_manager_tools = [
     update_epic_progress,
     read_epic_file,
     save_epic_decisions,
+    write_epic_doc,
+    list_epic_docs,
     # Per-repo analysis (epic-safe versions)
     repo_summarize_epic,
     repo_description_epic,

--- a/src/tokuye/tools/strands_tools/epic_tools/epic_dir_tools.py
+++ b/src/tokuye/tools/strands_tools/epic_tools/epic_dir_tools.py
@@ -15,6 +15,8 @@ Directory layout created by these tools:
         tasks.yaml       – task list with status
         progress.md      – running progress log
         decisions.md     – design decisions / notes
+        docs/
+          <filename>     – supplementary documents (user-instructed)
         results/
           <task_id>.yaml – per-task execution result
 """
@@ -54,6 +56,7 @@ def _ensure_epic_dir(epic_id: str) -> Path:
     d = _epic_dir(epic_id)
     d.mkdir(parents=True, exist_ok=True)
     (d / "results").mkdir(exist_ok=True)
+    (d / "docs").mkdir(exist_ok=True)
     return d
 
 
@@ -262,7 +265,7 @@ def save_epic_decisions(epic_id: str, decision: str) -> str:
     description=(
         "Read a file from the Epic working directory. "
         "Supported file names: epic.md, plan.md, tasks.yaml, progress.md, decisions.md, "
-        "or results/<task_id>.yaml."
+        "results/<task_id>.yaml, or docs/<filename> for supplementary documents."
     ),
 )
 def read_epic_file(epic_id: str, filename: str) -> str:
@@ -271,7 +274,8 @@ def read_epic_file(epic_id: str, filename: str) -> str:
     Args:
         epic_id: Epic identifier.
         filename: File name relative to the epic directory.
-                  Examples: 'plan.md', 'tasks.yaml', 'results/T001.yaml'
+                  Examples: 'plan.md', 'tasks.yaml', 'results/T001.yaml',
+                  'docs/api-spec.md'
 
     Returns:
         File contents as a string, or an error message if not found.
@@ -289,6 +293,78 @@ def read_epic_file(epic_id: str, filename: str) -> str:
         return f"File not found: {target}"
 
     return target.read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Supplementary document tools (docs/ subdirectory)
+# ---------------------------------------------------------------------------
+
+
+@tool(
+    name="write_epic_doc",
+    description=(
+        "Write a supplementary document to the docs/ subdirectory of an Epic. "
+        "Creates or overwrites docs/<filename>. "
+        "Use this when the user asks to create reference material, specs, "
+        "meeting notes, or any auxiliary document for the Epic. "
+        "filename must be a simple name (e.g. 'api-spec.md'); "
+        "subdirectories inside docs/ are not allowed."
+    ),
+)
+def write_epic_doc(epic_id: str, filename: str, content: str) -> str:
+    """Write a supplementary document to docs/<filename>.
+
+    Args:
+        epic_id: Epic identifier.
+        filename: File name inside the docs/ directory (e.g. 'api-spec.md').
+                  Must not contain path separators.
+        content: Full document content (Markdown or plain text).
+
+    Returns:
+        Confirmation message with file path, or an error message.
+    """
+    if "/" in filename or "\\" in filename:
+        return (
+            f"Error: filename must not contain path separators. "
+            f"Got: '{filename}'. Use a simple name like 'api-spec.md'."
+        )
+
+    d = _ensure_epic_dir(epic_id)
+    docs_dir = d / "docs"
+    target = docs_dir / filename
+
+    target.write_text(content, encoding="utf-8")
+    logger.info("Wrote epic doc: %s", target)
+    return f"Document saved to: {target}"
+
+
+@tool(
+    name="list_epic_docs",
+    description=(
+        "List supplementary documents in the docs/ subdirectory of an Epic. "
+        "Returns the file names inside docs/, or a message if the directory is empty."
+    ),
+)
+def list_epic_docs(epic_id: str) -> str:
+    """List files in the docs/ subdirectory of an Epic.
+
+    Args:
+        epic_id: Epic identifier.
+
+    Returns:
+        Newline-separated list of file names, or an informational message.
+    """
+    d = _epic_dir(epic_id)
+    docs_dir = d / "docs"
+
+    if not docs_dir.exists():
+        return "docs/ directory does not exist yet. Use write_epic_doc to create documents."
+
+    entries = sorted(f.name for f in docs_dir.iterdir() if f.is_file())
+    if not entries:
+        return "docs/ directory is empty."
+    return "\n".join(entries)
+
 
 # ---------------------------------------------------------------------------
 # Epic management directory — scoped read-only tools for EpicManagerAgent


### PR DESCRIPTION
## 概要

Epic モードで、各 Epic ディレクトリ内に `docs/` サブディレクトリを持ち、
Epic Manager がユーザーの指示に応じて補助ドキュメントを作成・管理できるようにする。

## 変更内容

### 新規ツール

| ツール | 説明 |
|---|---|
| `write_epic_doc` | `docs/<filename>` に補助ドキュメントを書く（新規作成・上書き） |
| `list_epic_docs` | `docs/` 内のファイル一覧を返す |

### 既存の変更

- **`_ensure_epic_dir`**: `results/` と同様に `docs/` も自動作成するよう追加
- **`read_epic_file`**: description に `docs/<filename>` も読める旨を追記（実装変更なし）
- **`__init__.py`**: 新ツールを `epic_manager_tools` に追加
- **システムプロンプト（JA/EN）**: `docs/` の使い方・ツール説明を追記

### ディレクトリ構造（変更後）

```
epics/<epic_id>/
  epic.md
  plan.md
  tasks.yaml
  progress.md
  decisions.md
  docs/              ← 新規
    <filename>       ← write_epic_doc で作成
  results/
    <task_id>.yaml
```

## 設計上の判断

- `read_epic_doc` は追加しない。`read_epic_file(epic_id, "docs/foo.md")` で既存の安全検証がそのまま効くため冗長
- `write_epic_doc` はファイル名にパスセパレータ（`/` `\`）を含む場合はエラーを返す（`docs/` 内のサブディレクトリ作成を禁止）
- 補助ドキュメントの作成はユーザーの明示的な指示がある場合のみ行う（自動生成しない）旨をプロンプトに明記

## 互換性

- 既存の Epic ディレクトリには `docs/` が存在しないが、次回 `_ensure_epic_dir` が呼ばれたタイミングで自動作成される（`exist_ok=True` なので冪等）
- 既存ツールの動作変更なし
